### PR TITLE
Add more inputs to configure Scala Steward execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
         with:
           github-repository: owner/repo
           github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          gpg-secret-key: ${{ secrets.GPG_SCALA_STEWARD }}
 ```
 
 If you want to be able to trigger the action manually, you can add a `repository_dispatch` event:
@@ -76,6 +77,33 @@ Otherwise, set it to the name of the repository to update in the form `owner/rep
 1. You will need to generate a [Github Personal Access Token](https://github.com/settings/tokens).
 2. Add it as a secret repository.
 3. Provide it to the action using `github-token`.
+
+### GPG
+
+1. Create a fresh GPG key:
+
+    ```bash
+    gpg --gen-key
+    ```
+
+    > :exclamation: Do not add a passphrase to the GPG key, since you won't be able to add it when Scala Steward writes a commit.
+
+2. Annotate the key ID from the previous command.
+3. Export the base64 encoded secret of your private key to the clipboard:
+    
+    ```bash
+    # macOS
+    gpg --armor --export-secret-keys $LONG_ID | base64 | pbcopy
+    # Ubuntu (assuming GNU base64)
+    gpg --armor --export-secret-keys $LONG_ID | base64 -w0 | xclip
+    # Arch
+    gpg --armor --export-secret-keys $LONG_ID | base64 | sed -z 's;\n;;g' | xclip -selection clipboard -i
+    # FreeBSD (assuming BSD base64)
+    gpg --armor --export-secret-keys $LONG_ID | base64 | xclip
+    ```
+4. Add it as a new `GPG_SCALA_STEWARD` repository secret.
+5. Provide it to the action using `gpg-secret-key`.
+6. Add your GPG key to the [user's Github Account](https://github.com/settings/keys)
 
 ## Credit
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   github-token:
     description: 'Github Personal Access Token with permission to create branches on repo'
     required: true
+  scala-steward-version:
+    description: 'Scala Steward version to use'
+    default: '0.5.0-385-e5e4789c-SNAPSHOT'
+    required: false
   sign-commits:
     description: 'Whether to sign commits or not'
     default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Scala Steward version to use'
     default: '0.5.0-385-e5e4789c-SNAPSHOT'
     required: false
+  ignore-opts-files:
+    description: 'Whether to ignore "opts" files (such as `.jvmopts` or `.sbtopts`) when found on repositories or not'
+    default: 'true'
+    required: false
   sign-commits:
     description: 'Whether to sign commits or not'
     default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   github-token:
     description: 'Github Personal Access Token with permission to create branches on repo'
     required: true
+  sign-commits:
+    description: 'Whether to sign commits or not'
+    default: 'false'
+    required: false
 
 runs:
   using: 'node12'

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function run(): Promise<void> {
     const version = core.getInput('scala-steward-version')
 
     const signCommits = /true/i.test(core.getInput('sign-commits'))
+    const ignoreOptsFiles = /true/i.test(core.getInput('ignore-opts-files'))
 
     await coursier.launch('org.scala-steward', 'scala-steward-core_2.13', version, [
       ['--workspace', '/opt/scala-steward/workspace'],
@@ -27,10 +28,10 @@ async function run(): Promise<void> {
       ['--vcs-login', `${user.login}"`],
       ['--env-var', '"SBT_OPTS=-Xmx2048m -Xss8m -XX:MaxMetaspaceSize=512m"'],
       ['--process-timeout', '20min'],
+      ignoreOptsFiles ? '--ignore-opts-files' : [],
+      signCommits ? '--sign-commits' : [],
       '--do-not-fork',
-      '--ignore-opts-files',
-      '--disable-sandbox',
-      signCommits ? ['--sign-commits'] : []
+      '--disable-sandbox'
     ])
   } catch (error) {
     core.setFailed(` ✕ ${error.message}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ async function run(): Promise<void> {
 
     const version = '0.5.0-385-e5e4789c-SNAPSHOT'
 
+    const signCommits = /true/i.test(core.getInput('sign-commits'))
+
     await coursier.launch('org.scala-steward', 'scala-steward-core_2.13', version, [
       ['--workspace', '/opt/scala-steward/workspace'],
       ['--repos-file', '/opt/scala-steward/repos.md'],
@@ -28,7 +30,7 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--ignore-opts-files',
       '--disable-sandbox',
-      '--sign-commits'
+      signCommits ? ['--sign-commits'] : []
     ])
   } catch (error) {
     core.setFailed(` ✕ ${error.message}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run(): Promise<void> {
 
     await files.prepareScalaStewardWorkspace(repo, token)
 
-    const version = '0.5.0-385-e5e4789c-SNAPSHOT'
+    const version = core.getInput('scala-steward-version')
 
     const signCommits = /true/i.test(core.getInput('sign-commits'))
 


### PR DESCRIPTION
# Which inputs have been added?

- `scala-steward-version`: to allow tweaking the Scala Steward version used
- `ignore-opts-files`: to allow enabling/disabling opts files
- `sign-commits`: to allow enabling/disabling signing commits

## Some notes regarding these new inputs

### Regarding `sign-commits`

This input can be used in conjunction with [crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg) to enable signing Scala Steward commits:

```yaml
- name: Import GPG key
  uses: crazy-max/ghaction-import-gpg@v2
  with:
    git_user_signingkey: true
  env:
    GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
    PASSPHRASE:      ${{ secrets.GPG_PASSPHRASE }}
- uses: scala-steward-org/scala-steward-action@master
  with:
    github-repository: 'alejandrohdezma/test'
    github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
    sign-commits: true
```

### Regarding `scala-steward-version`

One of the latest snapshot versions is used currently since there is no version published for Scala 2.13 on Sonatype. That's why we have to add the [`-r sonatype:snapshots`](https://github.com/scala-steward-org/scala-steward-action/blob/08b762d23db49155b81c06645c2585ca6eb3c956/src/coursier.ts#L63) argument to the `coursier launch` call. There are some things that could be tried to simplify this process:

1. Publish a new release of Scala Steward for Scala 2.13
2. Once a new version has been published, we could follow [this Coursier guide](https://get-coursier.io/docs/cli-install.html#creating-your-own-applications) to publish it as a Coursier application, which will enable launching it like:

```bash
cs launch scala-steward
```

What are your thoughts on ☝️ @fthomas?