### PR TITLE
Allow running Scala Steward on multiple repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: red
 
 inputs:
+  repos-file:
+    description: 'Path to a file containing the list of repositories to update in markdown format (- owner/repo)'
+    default: ''
+    required: false
   github-repository:
     description: 'Repository to update. The current repository will be used by default'
     default: ''

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch'
 import * as core from '@actions/core'
+import fs from 'fs'
 
 /**
  * Checks connection with Maven Central, throws error if unable to connect.
@@ -55,4 +56,32 @@ export function githubRepository(): string {
   core.info(`✓ Github Repository set to: ${repo}`)
 
   return repo
+}
+
+/**
+ * Reads the path of the file containing the list of repositories to update  from the `repos-file`
+ * input.
+ *
+ * If the input isn't provided this function will return `undefined`.
+ * On the other hand, if it is provided, it will check if the path exists:
+ * - If the file exists, its contents will be returned.
+ * - If it doesn't exists, an error will be thrown.
+ *
+ * @returns {string | undefined} The contents of the file indicated in `repos-file` input, if is
+ *                               defined; otherwise, `undefined`.
+ */
+export function reposFile(): Buffer | undefined {
+  const file: string | undefined = core.getInput('repos-file')
+
+  if (file === undefined) {
+    return undefined
+  }
+
+  if (fs.existsSync(file)) {
+    core.info(`✓ Using multiple repos file: ${file}`)
+
+    return fs.readFileSync(file)
+  }
+
+  throw new Error(`The path indicated in \`repos-file\` (${file}) does not exist`)
 }

--- a/src/files.ts
+++ b/src/files.ts
@@ -7,21 +7,28 @@ import * as exec from '@actions/exec'
  * Prepares the Scala Steward workspace that will be used when launching the app.
  *
  * This will involve:
- * - Creating a folder `/ops/scala-steward`
- * - Creating a `repos.md` file inside workspace containing the repository to update
+ * - Creating a folder `/ops/scala-steward`.
+ * - Creating a `repos.md` file inside workspace containing the repository/repositories to update.
  * - Creating a `askpass.sh` file inside workspace containing the Github token.
  * - Making the previous file executable.
  *
- * @param {string} repository - The repository to update.
+ * @param {string | Buffer} repository - The repository to update or a file containing a list of
+ *                                       repositories in Markdown format.
  * @param {string} token - The Github Token used to authenticate into Github.
  */
 export async function prepareScalaStewardWorkspace(
-  repository: string,
+  repository: Buffer | string,
   token: string
 ): Promise<void> {
   try {
     await io.mkdirP('/opt/scala-steward')
-    fs.writeFileSync('/opt/scala-steward/repos.md', `- ${repository}`)
+
+    if (typeof repository === 'string') {
+      fs.writeFileSync('/opt/scala-steward/repos.md', `- ${repository}`)
+    } else {
+      fs.writeFileSync('/opt/scala-steward/repos.md', repository)
+    }
+
     fs.writeFileSync('/opt/scala-steward/askpass.sh', `#!/bin/sh\n\necho '${token}'`)
     await exec.exec('chmod', ['+x', '/opt/scala-steward/askpass.sh'], {silent: true})
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function run(): Promise<void> {
     await check.mavenCentral()
     await coursier.install()
     const token = check.githubToken()
-    const repo = check.githubRepository()
+    const repo = check.reposFile() || check.githubRepository()
     const user = await github.getAuthUser(token)
 
     await files.prepareScalaStewardWorkspace(repo, token)


### PR DESCRIPTION
This PR introduces a new input `repos-file` that will allow users of this action to launch Scala Steward on multiple repositories (instead of just one).

# What has been done in this PR?

- Add a new input to `action.yml`: `repos-file`.
  - This new input will be used to provide the path to a file with the list of repositories to update in Markdown format. [Example](https://github.com/scala-steward-org/repos/blob/master/repos-github.md).
  - When present it will take precedence over `github-repository`.

# Example

An example of this new feature running on a repository can be found [here](https://github.com/alejandrohdezma/.github/runs/682600969?check_suite_focus=true).

# References

Closes #1 