### PR TITLE
Add workflow for automatically update major tag on minor release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1
+        with:
+          github_token: ${{ secrets. GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Action updates major version tags (e.g. v1, v2) when semantic versioning tag is pushed. If v1.2.3 tag is pushed, it updates v1 tag.