### PR TITLE
Use `ES2019` for Typescript compilation & change name of compiled file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,4 +36,4 @@ inputs:
 
 runs:
   using: 'node12'
-  main: 'dist/index.js'
+  main: 'dist/main.js'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A Github Action to launch Scala Steward in your repository",
   "main": "lib/main.js",
   "scripts": {
-    "build": "ncc build src/main.ts",
+    "build": "ncc build src/main.ts && mv dist/index.js dist/main.js",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A Github Action to launch Scala Steward in your repository",
   "main": "lib/main.js",
   "scripts": {
-    "build": "tsc && ncc build",
+    "build": "ncc build src/main.ts",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
-    "outDir": "./lib",
-    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2019",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
-    "esModuleInterop": true,
-    "lib": [
-      "es2019"
-    ]
+    "esModuleInterop": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
# What has been done in this PR?

- Use `ES2019` for Typescript compilation.
- Remove `outDir` & `rootDir` from `tsconfig.json` and tell `ncc` which files to build ([it can be directly pointed to Typescript files](https://github.com/vercel/ncc#with-typescript)).
- Compile current `main.ts` into `dist/main.js` instead of `dist/index.js`.