### PR TITLE
Add `post` step to cleanup files created by the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,3 +37,4 @@ inputs:
 runs:
   using: 'node12'
   main: 'dist/main.js'
+  post: 'dist/post.js'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "description": "A Github Action to launch Scala Steward in your repository",
   "main": "lib/main.js",
   "scripts": {
-    "build": "ncc build src/main.ts && mv dist/index.js dist/main.js",
+    "build": "npm run build-main && npm run build-post",
+    "build-main": "ncc build src/main.ts && mv dist/index.js dist/main.js",
+    "build-post": "ncc build src/post.ts && mv dist/index.js dist/post.js",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -80,3 +80,10 @@ export async function launch(
     throw new Error(`Launching ${name} failed`)
   }
 }
+
+/**
+ * Removes coursier binary
+ */
+export async function remove(): Promise<void> {
+  await io.rmRF(path.join(path.join(os.homedir(), 'bin'), 'cs'))
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from './github'
 import * as check from './check'
-import * as files from './files'
+import * as workspace from './workspace'
 import * as coursier from './coursier'
 
 /**
@@ -24,7 +24,7 @@ async function run(): Promise<void> {
     const authorEmail = core.getInput('author-email') || user.email()
     const authorName = core.getInput('author-name') || user.name()
 
-    const workspace = await files.prepareScalaStewardWorkspace(repo, token)
+    const workspaceDir = await workspace.prepare(repo, token)
 
     const version = core.getInput('scala-steward-version')
 
@@ -32,9 +32,9 @@ async function run(): Promise<void> {
     const ignoreOptsFiles = /true/i.test(core.getInput('ignore-opts-files'))
 
     await coursier.launch('org.scala-steward', 'scala-steward-core_2.13', version, [
-      ['--workspace', `${workspace}/workspace`],
-      ['--repos-file', `${workspace}/repos.md`],
-      ['--git-ask-pass', `${workspace}/askpass.sh`],
+      ['--workspace', `${workspaceDir}/workspace`],
+      ['--repos-file', `${workspaceDir}/repos.md`],
+      ['--git-ask-pass', `${workspaceDir}/askpass.sh`],
       ['--git-author-email', `${authorEmail}"`],
       ['--git-author-name', `${authorName}"`],
       ['--vcs-login', `${user.login}"`],

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,0 +1,19 @@
+import * as core from '@actions/core'
+import * as workspace from './workspace'
+import * as coursier from './coursier'
+
+/**
+ * Performs a cleanup of all the artifacts/folders created by this action.
+ */
+async function post(): Promise<void> {
+  try {
+    await workspace.remove()
+    core.info("🗑 Scala Steward's workspace removed")
+    await coursier.remove()
+    core.info('🗑 Coursier binary removed')
+  } catch (error) {
+    core.warning(error.message)
+  }
+}
+
+post()

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -18,10 +18,7 @@ import os from 'os'
  * @param {string} token - The Github Token used to authenticate into Github.
  * @returns {string} The workspace directory path
  */
-export async function prepareScalaStewardWorkspace(
-  repository: Buffer | string,
-  token: string
-): Promise<string> {
+export async function prepare(repository: Buffer | string, token: string): Promise<string> {
   try {
     const stewarddir = `${os.homedir()}/scala-steward`
     await io.mkdirP(stewarddir)

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -40,3 +40,10 @@ export async function prepare(repository: Buffer | string, token: string): Promi
     throw new Error('Unable to create Scala Steward workspace')
   }
 }
+
+/**
+ * Removes the Scala Steward's workspace.
+ */
+export async function remove(): Promise<void> {
+  await io.rmRF(`${os.homedir()}/scala-steward`)
+}


### PR DESCRIPTION
# Why?

Files created by this action are left behind once the action is over. This doesn't affect normal runs (those run in Github machinery) but [is a problem for those using a self-hosted runner](https://github.com/scala-steward-org/scala-steward-action/issues/52#issuecomment-638924197).

# What has been done?

Using the [`post` step of a Github Action](https://help.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#post) we can run a cleanup of files created by the action. In particular, it will be deleted both the Scala Steward workspace and the Coursier binary.

# [Example run](https://github.com/alejandrohdezma/test-scala-steward-action/runs/744842853?check_suite_focus=true)

![](https://user-images.githubusercontent.com/9027541/83940743-aae9ff00-a7e6-11ea-93a7-b14688b8a927.png)

# Related issue

This partially solves #52, caching of the workspace will be solved in a subsequent PR.