### PR TITLE
Save/restore Scala Steward workspace to/from cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,20 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@actions/cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-0.2.1.tgz",
+      "integrity": "sha512-CV2D9zp+d+nL7o6XK/I7vVh350JglPMp/jHi9ppRUkdBHPUeP0UHVUfygZaAs8WmxhhWY1MI0gWah+t0QYu3Fg==",
+      "requires": {
+        "@actions/core": "^1.2.4",
+        "@actions/exec": "^1.0.1",
+        "@actions/glob": "^0.1.0",
+        "@actions/http-client": "^1.0.8",
+        "@actions/io": "^1.0.1",
+        "semver": "^6.1.0",
+        "uuid": "^3.3.3"
+      }
+    },
     "@actions/core": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
@@ -25,6 +39,15 @@
         "@octokit/core": "^2.5.1",
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-rest-endpoint-methods": "^3.10.0"
+      }
+    },
+    "@actions/glob": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.1.0.tgz",
+      "integrity": "sha512-lx8SzyQ2FE9+UUvjqY1f28QbTJv+w8qP7kHHbfQRhphrlcx0Mdmm1tZdGJzfxv1jxREa/sLW4Oy8CbGQKCJySA==",
+      "requires": {
+        "@actions/core": "^1.2.0",
+        "minimatch": "^3.0.4"
       }
     },
     "@actions/http-client": {
@@ -1980,8 +2003,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2056,7 +2078,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2314,8 +2335,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -6703,7 +6723,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6547,6 +6547,11 @@
         "verror": "1.10.0"
       }
     },
+    "jssha": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.1.0.tgz",
+      "integrity": "sha512-tPCmr8xSLd8ug6N51k0rbF1tAQWZz1i/uCVHpCH9dl+Te+wM/T375R3lTexP3bk1HPmQ+NlJHQPYLmYuyk6slA=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "@actions/exec": "^1.0.4",
     "@actions/github": "^3.0.0",
     "@actions/tool-cache": "^1.5.5",
-    "@types/node-fetch": "^2.5.7"
+    "@types/node-fetch": "^2.5.7",
+    "jssha": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.11",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "alejandrohdezma",
   "license": "Apache-2.0",
   "dependencies": {
+    "@actions/cache": "^0.2.1",
     "@actions/core": "^1.2.4",
     "@actions/exec": "^1.0.4",
     "@actions/github": "^3.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ async function run(): Promise<void> {
     const authorName = core.getInput('author-name') || user.name()
 
     const workspaceDir = await workspace.prepare(repo, token)
+    await workspace.restoreWorkspaceCache(workspaceDir)
 
     const version = core.getInput('scala-steward-version')
 
@@ -45,6 +46,8 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--disable-sandbox'
     ])
+
+    await workspace.saveWorkspaceCache(workspaceDir)
   } catch (error) {
     core.setFailed(` ✕ ${error.message}`)
   }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -57,8 +57,9 @@ export async function saveWorkspaceCache(workspace: string): Promise<void> {
   try {
     core.startGroup('Saving workspace to cache...')
 
-    //We don't want to save the `store/refresh_error` folder in the cache
+    //We don't want to keep `workspace/store/refresh_error` nor `workspace/repos` in the cache.
     await io.rmRF(path.join(workspace, 'workspace', 'store', 'refresh_error'))
+    await io.rmRF(path.join(workspace, 'workspace', 'repos'))
 
     const hash = hashFile(path.join(workspace, 'repos.md'))
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,8 +1,10 @@
+import * as cache from '@actions/cache'
 import * as core from '@actions/core'
 import * as io from '@actions/io'
 import fs from 'fs'
 import * as exec from '@actions/exec'
 import os from 'os'
+import path from 'path'
 import jsSHA from 'jssha/dist/sha256'
 
 /**
@@ -16,6 +18,62 @@ export function hashFile(file: string): string {
   const sha = new jsSHA('SHA-256', 'TEXT', {encoding: 'UTF8'})
   sha.update(fs.readFileSync(file).toString())
   return sha.getHash('HEX').slice(0, 8)
+}
+
+/**
+ * Tries to restore the Scala Steward workspace build from the cache, if any.
+ *
+ * @param {string} workspace - the Scala Steward workspace directory
+ */
+export async function restoreWorkspaceCache(workspace: string): Promise<void> {
+  try {
+    core.startGroup('Trying to restore workspace contents from cache...')
+
+    const hash = hashFile(path.join(workspace, 'repos.md'))
+    const paths = [path.join(workspace, 'workspace')]
+    const cacheHit = await cache.restoreCache(
+      paths,
+      `scala-steward-${hash}-${Date.now().toString()}`,
+      [`scala-steward-${hash}`, 'scala-steward-']
+    )
+
+    if (cacheHit) core.info('Scala Steward workspace contents restored from cache')
+    else core.info("Scala Steward workspace contents weren't found on cache")
+
+    core.endGroup()
+  } catch (error) {
+    core.debug(error.message)
+    core.warning('Unable to restore workspace from cache')
+    core.endGroup()
+  }
+}
+
+/**
+ * Tries to save the Scala Steward workspace build to the cache.
+ *
+ * @param {string} workspace - the Scala Steward workspace directory
+ */
+export async function saveWorkspaceCache(workspace: string): Promise<void> {
+  try {
+    core.startGroup('Saving workspace to cache...')
+
+    //We don't want to save the `store/refresh_error` folder in the cache
+    await io.rmRF(path.join(workspace, 'workspace', 'store', 'refresh_error'))
+
+    const hash = hashFile(path.join(workspace, 'repos.md'))
+
+    await cache.saveCache(
+      [path.join(workspace, 'workspace')],
+      `scala-steward-${hash}-${Date.now().toString()}`
+    )
+
+    core.info('Scala Steward workspace contents saved to cache')
+    core.endGroup()
+  } catch (error) {
+    core.debug(error.message)
+    core.warning('Unable to save workspace to cache')
+    core.endGroup()
+  }
 }
 
 /**

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,6 +3,20 @@ import * as io from '@actions/io'
 import fs from 'fs'
 import * as exec from '@actions/exec'
 import os from 'os'
+import jsSHA from 'jssha/dist/sha256'
+
+/**
+ * Gets the first eight characters of the SHA-256 hash value for the
+ * provided file's contents.
+ *
+ * @param {string} file - the file for which to calculate the hash
+ * @returns {string} the file content's hash
+ */
+export function hashFile(file: string): string {
+  const sha = new jsSHA('SHA-256', 'TEXT', {encoding: 'UTF8'})
+  sha.update(fs.readFileSync(file).toString())
+  return sha.getHash('HEX').slice(0, 8)
+}
 
 /**
  * Prepares the Scala Steward workspace that will be used when launching the app.


### PR DESCRIPTION
# What has been done in this PR?

Add caching for the whole `workspace` folder where Scala Steward stores repositories and their metadata so subsequent builds are faster.

# Example run

[Here](https://github.com/alejandrohdezma/test-scala-steward-action/runs/748984721?check_suite_focus=true) is an example run with this new feature.

# References

This PR fixes #52 