### PR TITLE
fix Crashing when called getAuthUser was failed

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -40,7 +40,7 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
       }
     }
   } catch (error) {
-    core.debug(error)
+    core.debug(`- User information retrieve Error: ${error.message}`)
     throw new Error('Unable to retrieve user information from Github')
   }
 }


### PR DESCRIPTION

fix this issue
https://github.com/scala-steward-org/scala-steward-action/issues/104

This crash is triggered by `core.debug (error)`.

in my case,  i used `{secrets.GITHUB_TOKEN}` in github actions job.

`{secrets.GITHUB_TOKEN}` was invalid for using scala-steward-action bacause  this is not have permission for access `/user`.
and octokit throw exception.

i think this fix is good for troubleshooting in setup steward-action.
