### PR TITLE
Fix multiple repositories example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ To update multiple repositories you would need to perform the following steps:
 3. Provide it to the action using `repos-file`:
 
     ```yaml
+    # Need to checkout to read the markdown file
+    - uses: actions/checkout@v2
     - name: Launch Scala Steward
       uses: scala-steward-org/scala-steward-action@v2
       with:


### PR DESCRIPTION
I setup scala-steward-action for [multiple repositories](https://github.com/scala-steward-org/scala-steward-action#updating-multiple-repositories), but I didn't realize that need to [checkout](https://github.com/actions/checkout).

It's an elementary mistake, but I think it would be more user-friendly to add a checkout step to the example.