### PR TITLE
use github-actions[bot] account if token is "secrets.GITHUB_TOKEN"

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -29,7 +29,10 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
     core.debug(`- Name: ${name}`)
 
     return {
-      login,
+      login: () => {
+        if (!login) throw new Error('Unable to retrieve user information from Github')
+        return login
+      },
       email: () => {
         if (!email) throw new Error(emailErrorMessage)
         return email
@@ -41,12 +44,19 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
     }
   } catch (error) {
     core.debug(`- User information retrieve Error: ${error.message}`)
-    throw new Error('Unable to retrieve user information from Github')
+
+    // https://github.community/t/github-actions-bot-email-address/17204/6
+    // https://api.github.com/users/github-actions%5Bbot%5D
+    return {
+      login: () => 'github-actions[bot]',
+      email: () => '41898282+github-actions[bot]@users.noreply.github.com',
+      name: () => 'github-actions[bot]'
+    }
   }
 }
 
 interface AuthUser {
   email: () => string
-  login: string
+  login: () => string
   name: () => string
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ async function run(): Promise<void> {
       ['--git-ask-pass', `${workspaceDir}/askpass.sh`],
       ['--git-author-email', `${authorEmail}"`],
       ['--git-author-name', `${authorName}"`],
-      ['--vcs-login', `${user.login}"`],
+      ['--vcs-login', `${user.login()}"`],
       ['--env-var', '"SBT_OPTS=-Xmx2048m -Xss8m -XX:MaxMetaspaceSize=512m"'],
       ['--process-timeout', '20min'],
       ['--vcs-api-host', githubApiUrl],


### PR DESCRIPTION
GitHub Actions provide `secrets.GITHUB_TOKEN` by default.

https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow

But `github.users.getAuthenticated()` throw Error if `token` is `secrets.GITHUB_TOKEN`, so I have set explicit github-actions bot login, email and name.

https://github.community/t/github-actions-bot-email-address/17204/6

Here is an example repo.(I have't set any tokens in this repo. I have use only default `GITHUB_TOKEN`)
- https://github.com/xuwei-k/scala-steward-test-1/commit/d871418d30c944d750cddc4ae894fc46090a0f64
- https://github.com/xuwei-k/scala-steward-test-1/runs/1265240619#step:5:35
- https://github.com/xuwei-k/scala-steward-test-1/pull/1
