### PR TITLE
Install `Scalafmt` before running Scala Steward

### DIFF
--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -45,6 +45,29 @@ export async function selfInstall(): Promise<void> {
 }
 
 /**
+ * Installs an app using `coursier`.
+ *
+ * Refer to [coursier](https://get-coursier.io/docs/cli-launch) for more information.
+ *
+ * @param {string} app - The application's name.
+ */
+export async function install(app: string): Promise<void> {
+  core.startGroup(`Installing ${app}`)
+
+  const code = await exec.exec('cs', ['install', app], {
+    silent: true,
+    ignoreReturnCode: true,
+    listeners: {stdline: core.info, errline: core.error}
+  })
+
+  core.endGroup()
+
+  if (code !== 0) {
+    throw new Error(`Installing ${app} failed`)
+  }
+}
+
+/**
  * Launches an app using `coursier`.
  *
  * Refer to [coursier](https://get-coursier.io/docs/cli-launch) for more information.

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -10,7 +10,7 @@ import * as os from 'os'
  *
  * Throws error if the installation fails.
  */
-export async function install(): Promise<void> {
+export async function selfInstall(): Promise<void> {
   try {
     const temp = await tc.downloadTool('https://git.io/coursier-cli-linux')
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,8 @@ async function run(): Promise<void> {
     const cacheTTL = core.getInput('cache-ttl')
     const githubApiUrl = core.getInput('github-api-url')
 
+    await coursier.install('scalafmt')
+
     await coursier.launch('org.scala-steward', 'scala-steward-core_2.13', version, [
       ['--workspace', `${workspaceDir}/workspace`],
       ['--repos-file', `${workspaceDir}/repos.md`],

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import * as coursier from './coursier'
 async function run(): Promise<void> {
   try {
     await check.mavenCentral()
-    await coursier.install()
+    await coursier.selfInstall()
     const token = check.githubToken()
     const repo = check.reposFile() || check.githubRepository()
     const user = await github.getAuthUser(token)


### PR DESCRIPTION
# What changes are included in this PR?

- Rename `coursier#install` to `coursier#selfInstall`
- Add a new method to allow installing apps through coursier with [`cs install`](https://get-coursier.io/docs/cli-install)
- Install [Scalafmt](https://scalameta.org/scalafmt/) before running Scala Steward.

# Related

This PR fixes #187 