### PR TITLE
Fix a bug when installing Scalafmt that was preventing the action from working

### DIFF
--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -55,7 +55,7 @@ export async function install(app: string): Promise<void> {
   const homedir = os.homedir()
   const binPath = path.join(homedir, 'bin')
 
-  const code = await exec.exec('cs', ['install', app, '--install-dir', binPath], {
+  let code = await exec.exec('cs', ['install', app, '--install-dir', binPath], {
     silent: true,
     ignoreReturnCode: true,
     listeners: {stdline: core.info, errline: core.debug}
@@ -64,6 +64,20 @@ export async function install(app: string): Promise<void> {
   if (code !== 0) {
     throw new Error(`Installing ${app} failed`)
   }
+
+  let version = ''
+
+  code = await exec.exec(app, ['--version'], {
+    silent: true,
+    ignoreReturnCode: true,
+    listeners: {stdout: data => (version += data.toString()), errline: core.error}
+  })
+
+  if (code !== 0) {
+    throw new Error(`Installing ${app} failed`)
+  }
+
+  core.info(`✓ ${app} installed, version: ${version.trim()}`)
 }
 
 /**
@@ -108,4 +122,5 @@ export async function launch(
  */
 export async function remove(): Promise<void> {
   await io.rmRF(path.join(path.join(os.homedir(), 'bin'), 'cs'))
+  await io.rmRF(path.join(path.join(os.homedir(), 'bin'), 'scalafmt'))
 }

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -52,15 +52,14 @@ export async function selfInstall(): Promise<void> {
  * @param {string} app - The application's name.
  */
 export async function install(app: string): Promise<void> {
-  core.startGroup(`Installing ${app}`)
+  const homedir = os.homedir()
+  const binPath = path.join(homedir, 'bin')
 
-  const code = await exec.exec('cs', ['install', app], {
+  const code = await exec.exec('cs', ['install', app, '--install-dir', binPath], {
     silent: true,
     ignoreReturnCode: true,
-    listeners: {stdline: core.info, errline: core.error}
+    listeners: {stdline: core.info, errline: core.debug}
   })
-
-  core.endGroup()
 
   if (code !== 0) {
     throw new Error(`Installing ${app} failed`)


### PR DESCRIPTION
# What are the changes included?

- Ensure installed coursier apps are installed in a directory that is already in the path (like the one courier gets installed to).
- Instead of showing a log group like `Installing my-app...` show the version of the installed app

# Acknowledgment

Thanks to @hmemcpy for [discovering](https://twitter.com/hmemcpy/status/1329047672527986690) this error.

