### PR TITLE
Fixed example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
 ```
 
 ### How can I trigger a run?

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+name: Launch Scala Steward
+
 jobs:
   scala-steward:
     runs-on: ubuntu-latest
@@ -34,7 +36,7 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:
-          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### How can I trigger a run?


### PR DESCRIPTION
I just fixed the example in the README.md with the correct name for the GITHUB_TOKEN env variable plus I suggest to give a name to the workflow in order to do not visualize .github/workflows/scala-steward.yml as the action name