### PR TITLE
Auto enable `LOG_LEVEL=TRACE` in Scala Steward if using "step debug logging"

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,12 @@ By default, Scala Steward will ignore "opts" files (such as `.jvmopts` or `.sbto
     ignore-opts-files: false
 ```
 
+### Run Scala Steward in debug mode
+
+You just need to enable [GitHub Actions' "step debug logging"](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) and Scala Steward will start automatically in debug mode too.
+
+For this you must set the following secret in the repository that contains the workflow: `ACTIONS_STEP_DEBUG` to `true` (as stated in GitHub's documentation).
+
 ## License
 
 Scala Steward Action is licensed under the Apache License, Version 2.0.

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -102,9 +102,11 @@ export async function launch(
 ): Promise<void> {
   const name = `${org}:${app}:${version}`
 
+  const debug = 'ACTIONS_STEP_DEBUG' in process.env ? ['--java-opt', '-DLOG_LEVEL=TRACE'] : []
+
   core.startGroup(`Launching ${name}`)
 
-  const launchArgs = ['launch', '-r', 'sonatype:snapshots', name, '--'].concat(
+  const launchArgs = ['launch', '-r', 'sonatype:snapshots'].concat(debug).concat([name, '--']).concat(
     args.flatMap((arg: string | string[]) => (typeof arg === 'string' ? [arg] : arg))
   )
 

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -102,7 +102,7 @@ export async function launch(
 ): Promise<void> {
   const name = `${org}:${app}:${version}`
 
-  const debug = 'ACTIONS_STEP_DEBUG' in process.env ? ['--java-opt', '-DLOG_LEVEL=TRACE'] : []
+  const debug = 'ACTIONS_STEP_DEBUG' in process.env ? ['--java-opt', '-DLOG_LEVEL=TRACE', '-DROOT_LOG_LEVEL=TRACE'] : []
 
   core.startGroup(`Launching ${name}`)
 


### PR DESCRIPTION
This PR enables starting Scala Steward with the `LOG_LEVEL=TRACE` java option if ["step debug logging"](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) is activated. 

For this you must set the following secret in the repository that contains the workflow: `ACTIONS_STEP_DEBUG` to `true` (as stated in GitHub's documentation).
