### PR TITLE
Update to Scala Steward 0.13 as default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following inputs are available (all of them are optional):
 | <details><summary>`github-token`</summary><br/>Github Personal Access Token with permission to create branches on repo (or `${{ secrets.GITHUB_TOKEN }}`)</details> | Valid [Github Token](https://github.com/settings/tokens) | `''` |
 | <details><summary>`author-email`</summary><br/>Author email address to use in commits</details> | Email address | Github user's *Public email* |
 | <details><summary>`author-name`</summary><br/>Author name to use in commits</details> | String | Github user's *Name* |
-| <details><summary>`scala-steward-version`</summary><br/>Scala Steward version to use</details> | Valid [Scala Steward's version](https://github.com/scala-steward-org/scala-steward/releases) | `0.12.0` |
+| <details><summary>`scala-steward-version`</summary><br/>Scala Steward version to use</details> | Valid [Scala Steward's version](https://github.com/scala-steward-org/scala-steward/releases) | `0.13.0` |
 | <details><summary>`ignore-opts-files`</summary><br/>Whether to ignore "opts" files (such as `.jvmopts` or `.sbtopts`) when found on repositories or not</details> | true/false | `true` |
 | <details><summary>`sign-commits`</summary><br/>Whether to sign commits or not</details> | true/false | `false` |
 | <details><summary>`cache-ttl`</summary><br/>TTL of cache for fetching dependency versions and metadata. Set it to `0s` to disable cache completely.</details> | like 24hours, 5min, 10s, or 0s | `2hours` |

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
   scala-steward-version:
     description: "Scala Steward version to use"
-    default: "0.12.0"
+    default: "0.13.0"
     required: false
   ignore-opts-files:
     description: 'Whether to ignore "opts" files (such as `.jvmopts` or `.sbtopts`) when found on repositories or not'


### PR DESCRIPTION
It was released yesterday: [Scala Steward 0.13.0](https://github.com/scala-steward-org/scala-steward/releases/tag/v0.13.0).