### PR TITLE
Add signing-key input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,35 @@ If you want commits created by Scala Steward to be automatically signed with a G
         sign-commits: true
     ```
 
-8. **Optional**. By default, Scala Steward will use the email/name of the user that created the token added in `github-token`, if you want to override that behavior, you can use `author-email`/`author-name` inputs, for example with the values extracted from the imported private key:
+8. Tell Scala Steward the key ID of the key to be used for signing commits using the `signing-key` input:
+
+   1. Obtain the key ID for the key that should be used. For instance, in the following example, the GPG key ID is
+      3AA5C34371567BD2:
+
+      ```
+      $ gpg --list-secret-keys --keyid-format=long
+      /Users/hubot/.gnupg/secring.gpg
+      ------------------------------------
+      sec   4096R/3AA5C34371567BD2 2016-03-10 [expires: 2017-03-10]
+      uid                          Hubot
+      ssb   4096R/42B317FD4BA89E7A 2016-03-10
+      ```
+
+   3. Copy the key ID and paste it as the content of a new repository secret, called for example `GPG_SIGNING_KEY_ID`.
+
+   4. Use the `signing-key` parameter to allow Scala Steward to use the correct key:
+
+      ```yaml
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          sign-commits: true
+          signing-key: ${{ secrets.GPG_SIGNING_KEY_ID }}
+      ```
+
+
+9. **Optional**. By default, Scala Steward will use the email/name of the user that created the token added in `github-token`, if you want to override that behavior, you can use `author-email`/`author-name` inputs, for example with the values extracted from the imported private key:
 
     ```yaml
     - name: Launch Scala Steward

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following inputs are available (all of them are optional):
 | <details><summary>`scala-steward-version`</summary><br/>Scala Steward version to use</details> | Valid [Scala Steward's version](https://github.com/scala-steward-org/scala-steward/releases) | `0.12.0` |
 | <details><summary>`ignore-opts-files`</summary><br/>Whether to ignore "opts" files (such as `.jvmopts` or `.sbtopts`) when found on repositories or not</details> | true/false | `true` |
 | <details><summary>`sign-commits`</summary><br/>Whether to sign commits or not</details> | true/false | `false` |
+| <details><summary>`signing-key`</summary><br/>Key ID of signing key to use for signing commits. Analogous to git's `user.signingkey` configuration setting.</details> | Signing key ID | ' ' |
 | <details><summary>`cache-ttl`</summary><br/>TTL of cache for fetching dependency versions and metadata. Set it to `0s` to disable cache completely.</details> | like 24hours, 5min, 10s, or 0s | `2hours` |
 | <details><summary>`timeout`</summary><br/>Timeout for external process invocations.</details> | like 2hours, 5min, 10s, or 0s | `20min` |
 | <details><summary>`github-api-url`</summary><br/>The URL of the Github API, only use this input if you are using Github Enterprise</details> | https://git.yourcompany.com/api/v3 | `https://api.github.com` |

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: "Whether to sign commits or not"
     default: "false"
     required: false
+  signing-key:
+    description: "Key ID of GPG key to use for signing commits."
+    default: ""
+    required: false
   timeout:
     description: "Timeout for external process invocations"
     default: "20min"

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ async function run(): Promise<void> {
     const version = core.getInput('scala-steward-version')
 
     const signCommits = /true/i.test(core.getInput('sign-commits'))
+    const signingKey = core.getInput("signing-key")
     const ignoreOptionsFiles = /true/i.test(core.getInput('ignore-opts-files'))
     const githubApiUrl = core.getInput('github-api-url')
     const scalafixMigrations = core.getInput('scalafix-migrations') ?
@@ -74,6 +75,7 @@ async function run(): Promise<void> {
       ['--vcs-api-host', githubApiUrl],
       ignoreOptionsFiles ? '--ignore-opts-files' : [],
       signCommits ? '--sign-commits' : [],
+      signingKey ? ['--git-author-signing-key', signingKey] : [],
       ['--cache-ttl', cacheTTL],
       scalafixMigrations,
       artifactMigrations,


### PR DESCRIPTION
Currently there is no way to set Scala Steward's `--git-author-signing-key` option. This adds an optional `signing-key` configuration parameter.