### PR TITLE
Workspace should always be restored

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,9 +37,7 @@ async function run(): Promise<void> {
 
     const cacheTtl = core.getInput('cache-ttl')
 
-    if (cacheTtl !== '0s') {
-      await workspace.restoreWorkspaceCache(workspaceDir)
-    }
+    await workspace.restoreWorkspaceCache(workspaceDir)
 
     const timeout = core.getInput('timeout')
 
@@ -86,9 +84,7 @@ async function run(): Promise<void> {
       githubAppArgs,
     ])
 
-    if (cacheTtl !== '0') {
-      await workspace.saveWorkspaceCache(workspaceDir)
-    }
+    await workspace.saveWorkspaceCache(workspaceDir)
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)
   }


### PR DESCRIPTION
Scala Steward workspace should always be restored (even if `cache-ttl` is set to `0`). If not, old PRs won't be closed.

Thanks to @milanvdm for helping out finding this :)