### PR TITLE
Update to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,6 @@ inputs:
     required: false
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/main.js"
   post: "dist/post.js"


### PR DESCRIPTION
The official GH actions have been updating e.g. https://github.com/actions/checkout/releases/tag/v3.0.0.

Also Node 12 EOL on April 30, 2022. https://nodejs.org/en/about/releases/