### PR TITLE
Save workspace always

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,11 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--disable-sandbox',
       githubAppArgs,
-    ]).finally(() => workspace.saveWorkspaceCache(workspaceDir))
+    ]).finally(() => {
+      workspace.saveWorkspaceCache(workspaceDir).catch((error: unknown) => {
+        core.setFailed(` ✕ ${(error as Error).message}`)
+      })
+    })
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,9 +82,7 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--disable-sandbox',
       githubAppArgs,
-    ])
-
-    await workspace.saveWorkspaceCache(workspaceDir)
+    ]).finally(() => workspace.saveWorkspaceCache(workspaceDir))
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)
   }


### PR DESCRIPTION
This change makes sure the workspace is saved, regarding the outcome of launching Scala Steward, as suggested by @fthomas [here](https://github.com/scala-steward-org/scala-steward-action/issues/367#issuecomment-1146740861).