### PR TITLE
Fix debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,12 @@ By default, Scala Steward will ignore "opts" files (such as `.jvmopts` or `.sbto
 
 You just need to enable [GitHub Actions' "step debug logging"](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) and Scala Steward will start automatically in debug mode too.
 
+> Alternatively, if you are re-running a failed job and want to re-run it in debug
+> mode, follow this tutorial and check `Enable debug logging` before clicking on
+> `Re-run jobs`.
+>
+> ![](https://docs.github.com/assets/cb-11530/images/help/repository/enable-debug-logging.png)
+
 For this you must set the following secret in the repository that contains the workflow: `ACTIONS_STEP_DEBUG` to `true` (as stated in GitHub's documentation).
 
 ## Contributors

--- a/src/coursier.ts
+++ b/src/coursier.ts
@@ -107,15 +107,12 @@ export async function launch(
 ): Promise<void> {
   const name = `${org}:${app}:${version}`
 
-  const debug = 'ACTIONS_STEP_DEBUG' in process.env ? ['--java-opt', '-DLOG_LEVEL=TRACE', '-DROOT_LOG_LEVEL=TRACE'] : []
-
   core.startGroup(`Launching ${name}`)
 
   const launchArgs = [
     'launch',
     '-r',
     'sonatype:snapshots',
-    ...debug,
     name,
     '--',
     ...args.flatMap((arg: string | string[]) => (typeof arg === 'string' ? [arg] : arg)),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import {Buffer} from 'buffer'
+import process from 'process'
 import * as core from '@actions/core'
 import * as github from './github'
 import * as check from './check'
@@ -59,6 +60,12 @@ async function run(): Promise<void> {
     const githubAppArgs = githubAppInfo
       ? ['--github-app-id', githubAppInfo.id, '--github-app-key-file', githubAppInfo.keyFile]
       : []
+
+    if (process.env.RUNNER_DEBUG) {
+      core.debug('Debug mode activated for Scala Steward')
+      core.exportVariable('LOG_LEVEL', 'TRACE')
+      core.exportVariable('ROOT_LOG_LEVEL', 'TRACE')
+    }
 
     const otherArgs = core.getInput('other-args')
       ? core.getInput('other-args').split(' ')


### PR DESCRIPTION
The environment variables for starting Scala Steward on debug mode must be present on the environment (instead of passing them to coursier). Also, the environment variable to check if debug mode is enabled has changed: it is now always `RUNNER_DEBUG=1` (even when you set the `ACTIONS_STEP_DEBUG` variable GitHub will replace it with `RUNNER_DEBUG`).

Fixes #388.