### PR TITLE
feat: ensure Mill is installed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as github from './github'
 import * as check from './check'
 import * as workspace from './workspace'
 import * as coursier from './coursier'
+import * as mill from './mill'
 
 /**
  * Runs the action main code. In order it will do the following:
@@ -73,6 +74,7 @@ async function run(): Promise<void> {
 
     await coursier.install('scalafmt')
     await coursier.install('scalafix')
+    await mill.install()
 
     await coursier.launch('org.scala-steward', 'scala-steward-core_2.13', version, [
       ['--workspace', `${workspaceDir}/workspace`],

--- a/src/mill.ts
+++ b/src/mill.ts
@@ -1,0 +1,56 @@
+import * as os from 'os'
+import * as path from 'path'
+import * as core from '@actions/core'
+import * as io from '@actions/io'
+import * as tc from '@actions/tool-cache'
+import * as exec from '@actions/exec'
+
+export async function install(): Promise<string> {
+  try {
+    const millVersion = core.getInput('mill-version') || '0.10.9'
+
+    const cachedPath = tc.find('mill', millVersion)
+
+    if (!cachedPath) {
+      const millUrl = `https://github.com/lihaoyi/mill/releases/download/${millVersion}/${millVersion}`
+
+      core.debug(`Attempting to install Mill from ${millUrl}`)
+
+      const millDownload = await tc.downloadTool(millUrl)
+
+      await exec.exec('chmod', ['+x', millDownload], {silent: true, ignoreReturnCode: true})
+
+      const homedir = os.homedir()
+
+      const binPath = path.join(homedir, 'bin')
+
+      const millBin = path.join(binPath, 'mill')
+
+      await io.mv(millDownload, millBin)
+
+      await tc.cacheFile(millBin, 'mill', 'mill', millVersion)
+    }
+  } catch (error: unknown) {
+    core.error((error as Error).message)
+    throw new Error('Unable to install Mill')
+  }
+
+  let version = ''
+
+  const code = await exec.exec('mill', ['--version'], {
+    silent: true,
+    ignoreReturnCode: true,
+    listeners: {
+      stdout(data) {
+        (version += data.toString())
+      }, errline: core.error,
+    },
+  })
+
+  if (code !== 0) {
+    throw new Error('Unable to install Mill')
+  }
+
+  core.info(`✓ Mill installed, version: ${version.trim()}`)
+  return version
+}


### PR DESCRIPTION
**The problem**

So when using this action I was a little thrown off that it was failing with:

```
java.io.IOException: Cannot run program "mill" (in directory "/home/runner/scala-steward/workspace/repos/scalacenter/bloop-config"): error=2, No such file or directory
```

I would expect the action to ensure what's needed is installed. I'm assuming no one hits on this for sbt due to it always being there in the ubuntu image.

**The fix**

This change ensures that `mill` is always there and installed.

**NOTE**

Sort of opening this up just to discuss since it came up in https://github.com/scala-steward-org/scala-steward/issues/2803. If this is an ok approach I'll add some docs. Also, I have no idea how to test this using the tool-cache. Any ideas how to test this? I see the other installations like `cs` aren't tested at all, so maybe this is fine. We could in theory do a `coursier.install('mill')`, which would be loads easier, but it's not an official way to install Mill.