### PR TITLE
fix: instead of moving mill cp and then remove

### DIFF
--- a/src/mill.ts
+++ b/src/mill.ts
@@ -26,7 +26,13 @@ export async function install(): Promise<string> {
 
       const millBin = path.join(binPath, 'mill')
 
-      await io.mv(millDownload, millBin)
+      // We first copy and then remove here to avoid this
+      // https://stackoverflow.com/questions/44146393/error-exdev-cross-device-link-not-permitted-rename-nodejs
+      // This idea is taken from https://github.com/shelljs/shelljs/pull/187
+      // It didn't get merged there, but for our usecase just mimicking this
+      // should hopefully work fine.
+      await io.cp(millDownload, millBin)
+      await io.rmRF(millDownload)
 
       await tc.cacheFile(millBin, 'mill', 'mill', millVersion)
     }


### PR DESCRIPTION
It looks like there are situations when dealing with mounted drives
you get the following error:

```
Error: EXDEV: cross-device link not permitted, rename '/runner/_work/_temp/9b722d14-6935-45f9-ab1a-526911088cbe' -> '/home/runner/bin/mill'
```

From googling around it looks like we can avoid this by instead
moving the file first and then removing it.

For reference

- https://stackoverflow.com/questions/44146393/error-exdev-cross-device-link-not-permitted-rename-nodejs
- https://github.com/shelljs/shelljs/issues/191

Fixes: #421
