### PR TITLE
Update Coursier installation process

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -207,7 +207,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/2632023?v=4",
       "profile": "https://github.com/ybasket",
       "contributions": [
-        "code"
+        "code",
+        "bug"
       ]
     },
     {

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ inputs:
     required: false
   coursier-cli-url:
     description: "Url to download the coursier linux CLI from"
-    default: "https://git.io/coursier-cli-linux"
+    default: "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz"
     required: false
   ignore-opts-files:
     description: 'Whether to ignore "opts" files (such as `.jvmopts` or `.sbtopts`) when found on repositories or not'

--- a/src/action/pre.ts
+++ b/src/action/pre.ts
@@ -2,12 +2,11 @@ import * as core from '@actions/core'
 import fetch from 'node-fetch'
 import * as coursier from '../modules/coursier'
 import {HealthCheck} from '../modules/healthcheck'
-import {type HttpClient} from '../core/http'
-import {type Logger} from '../core/logger'
 import * as mill from '../modules/mill'
 
 /**
  * Runs the action pre-requisites code. In order it will do the following:
+ *
  * - Check connection with Maven Central
  * - Install Coursier
  * - Install Scalafmt
@@ -16,10 +15,7 @@ import * as mill from '../modules/mill'
  */
 async function run(): Promise<void> {
   try {
-    const logger: Logger = core
-    const httpClient: HttpClient = {run: async url => fetch(url)}
-    const healthCheck: HealthCheck = HealthCheck.from(logger, httpClient)
-
+    const healthCheck: HealthCheck = HealthCheck.from(core, {run: async url => fetch(url)})
     await healthCheck.mavenCentral()
 
     await coursier.selfInstall()


### PR DESCRIPTION
We were using an outdated link for downloading Coursier.

With the new version we can also benefit from `cs uninstall` to remove the data installed by Coursier.