### PR TITLE
Remove unneeded code

### DIFF
--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -105,11 +105,8 @@ export async function remove(): Promise<void> {
   await exec.exec('cs', ['uninstall', '--all'], {
     silent: true,
     ignoreReturnCode: true,
-    listeners: {stdline: core.info, errline: core.error},
+    listeners: {stdline: core.info, errline: core.debug},
   })
-  await io.rmRF(path.join(os.homedir(), 'bin', 'cs'))
-  await io.rmRF(path.join(os.homedir(), 'bin', 'scalafmt'))
-  await io.rmRF(path.join(os.homedir(), 'bin', 'scalafix'))
 }
 
 /**


### PR DESCRIPTION
These are already removed by `cs uninstall`. They are causing a `Nothing to remove` error to appear on Action pages.