### PR TITLE
Stop installing JVM

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -99,6 +99,14 @@ inputs:
       or `.sbtopts`) when found on repositories or not.
     default: "true"
     required: false
+  mill-version:
+    description: |
+      Mill version to install. Take into account this will
+      just affect the global `mill` executable. Scala 
+      Steward will still respect the version specified in
+      your repository while updating it.
+    default: "0.10.9"
+    required: false
   other-args:
     description: |
       Other Scala Steward arguments not yet supported by

--- a/src/action/pre.ts
+++ b/src/action/pre.ts
@@ -9,7 +9,6 @@ import * as mill from '../modules/mill'
  *
  * - Check connection with Maven Central
  * - Install Coursier
- * - Install JVM
  * - Install Scalafmt
  * - Install Scalafix
  * - Install Mill

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -43,11 +43,11 @@ export async function install(): Promise<void> {
 
     core.info(`✓ Coursier installed, version: ${coursierVersion.trim()}`)
 
-    const scalafmtVersion = await execute('scalafmt', '--version')
+    const scalafmtVersion = await execute('cs', 'launch', 'scalafmt', '--', '--version')
 
     core.info(`✓ Scalafmt installed, version: ${scalafmtVersion.replace(/^scalafmt /, '').trim()}`)
 
-    const scalafixVersion = await execute('scalafix', '--version')
+    const scalafixVersion = await execute('cs', 'launch', 'scalafix', '--', '--version')
 
     core.info(`✓ Scalafix installed, version: ${scalafixVersion.trim()}`)
   } catch (error: unknown) {

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -32,7 +32,7 @@ export async function install(): Promise<void> {
 
     await exec.exec(
       'cs',
-      ['setup', '--yes', '--jvm', 'adoptium:17', '--apps', 'scalafmt,scalafix', '--install-dir', binPath],
+      ['install', 'scalafmt', 'scalafix', '--install-dir', binPath],
       {
         silent: true,
         listeners: {stdline: core.debug, errline: core.debug},

--- a/src/modules/mill.ts
+++ b/src/modules/mill.ts
@@ -33,25 +33,7 @@ export async function install(): Promise<void> {
       await tc.cacheFile(mill, 'mill', 'mill', millVersion)
     }
 
-    let output = ''
-
-    const code = await exec.exec('mill', ['--version'], {
-      silent: true,
-      ignoreReturnCode: true,
-      listeners: {
-        stdout(data) {
-          (output += data.toString())
-        }, errline: core.debug,
-      },
-    })
-
-    if (code !== 0) {
-      throw new Error('Unable to install Mill')
-    }
-
-    const version = output.split('\n')[0].replace(/^Mill Build Tool version /, '').trim()
-
-    core.info(`✓ Mill installed, version: ${version}`)
+    core.info(`✓ Mill installed, version: ${millVersion}`)
   } catch (error: unknown) {
     core.error((error as Error).message)
     throw new Error('Unable to install Mill')

--- a/src/modules/mill.ts
+++ b/src/modules/mill.ts
@@ -12,7 +12,7 @@ import * as exec from '@actions/exec'
  */
 export async function install(): Promise<void> {
   try {
-    const millVersion = core.getInput('mill-version') || '0.10.9'
+    const millVersion = core.getInput('mill-version')
 
     const cachedPath = tc.find('mill', millVersion)
 


### PR DESCRIPTION
It seems installing JVM causes many problems on self-hosted runners. So instead of ensuring a JVM is installed, we leave that responsibility to the user.