### PR TITLE
Add support for setting Coursier's `--extra-jars` option when launching Scala Steward

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
       Url to download the coursier linux CLI from.
     default: https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz
     required: false
+  extra-jars:
+    description: |
+      Extra JARs to be added to the classpath of the
+      launched application. Directories accepted too.
+    required: false
   github-api-url:
     description: |
       The URL of the GitHub API, only use this input if

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -68,7 +68,7 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--disable-sandbox',
       inputs.steward.extraArgs?.value.split(' ') ?? [],
-    ])
+    ], inputs.steward.extraJars)
 
     await workspace.saveWorkspaceCache()
   } catch (error: unknown) {

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -66,11 +66,13 @@ export async function install(): Promise<void> {
  * @param app - The application's artifact name.
  * @param version - The application's version.
  * @param args - The args to pass to the application launcher.
+ * @param extraJars - Extra JARs to be added to the classpath of the launched application. Directories accepted too.
  */
 export async function launch(
   app: string,
   version: NonEmptyString | undefined,
-  args: Array<string | string[]> = [],
+  args: Array<string | string[]>,
+  extraJars: NonEmptyString | undefined,
 ): Promise<void> {
   const name = version ? `${app}:${version.value}` : app
 
@@ -78,6 +80,7 @@ export async function launch(
 
   const launchArgs = [
     'launch',
+    ...(extraJars ? ['--extra-jars', extraJars.value] : []),
     '--contrib',
     '-r',
     'sonatype:snapshots',

--- a/src/modules/input.test.ts
+++ b/src/modules/input.test.ts
@@ -22,6 +22,7 @@ test('`Input.all` → returns all inputs', t => {
     .with('scalafix-migrations', () => '.github/scalafix-migrations.conf')
     .with('other-args', () => '--help')
     .with('signing-key', () => '42')
+    .with('extra-jars', () => 'path/to/my/jars')
     .otherwise(() => '')
 
   const booleanInputs = (name: string) => match(name)
@@ -54,6 +55,7 @@ test('`Input.all` → returns all inputs', t => {
       timeout: nonEmpty('60s'),
       ignoreOptsFiles: true,
       extraArgs: nonEmpty('--help'),
+      extraJars: nonEmpty('path/to/my/jars'),
     },
     migrations: {
       scalafix: nonEmpty('.github/scalafix-migrations.conf'),

--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -46,6 +46,7 @@ export class Input {
         timeout: nonEmpty(this.inputs.getInput('timeout')),
         ignoreOptsFiles: this.inputs.getBooleanInput('ignore-opts-files'),
         extraArgs: nonEmpty(this.inputs.getInput('other-args')),
+        extraJars: nonEmpty(this.inputs.getInput('extra-jars')),
       },
       migrations: {
         scalafix: nonEmpty(this.inputs.getInput('scalafix-migrations')),


### PR DESCRIPTION
This feature allows injecting JARs when running Steward.

Fixes #466