### PR TITLE
Display GitHub Action Job Summary

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -70,13 +70,13 @@ async function run(): Promise<void> {
       inputs.steward.extraArgs?.value.split(' ') ?? [],
     ])
 
-    if (this.files.existsSync(workspace.runSummary_md)) {
-      this.logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
+    if (files.existsSync(workspace.runSummary_md)) {
+      logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
 
-      const summaryMarkdown = this.files.readFileSync(workspace.runSummary_md, 'utf8')
+      const summaryMarkdown = files.readFileSync(workspace.runSummary_md, 'utf8')
       await core.summary.addRaw(summaryMarkdown).write()
     }
-    
+
     await workspace.saveWorkspaceCache()
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -70,6 +70,13 @@ async function run(): Promise<void> {
       inputs.steward.extraArgs?.value.split(' ') ?? [],
     ])
 
+    if (this.files.existsSync(workspace.runSummary_md)) {
+      this.logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
+
+      const summaryMarkdown = this.files.readFileSync(workspace.runSummary_md, 'utf8')
+      await core.summary.addRaw(summaryMarkdown).write()
+    }
+    
     await workspace.saveWorkspaceCache()
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -22,6 +22,7 @@ export class Workspace {
   readonly repos_md = mandatory(path.join(this.directory, 'repos.md'))
   readonly app_pem = mandatory(path.join(this.directory, 'app.pem'))
   readonly askpass_sh = mandatory(path.join(this.directory, 'askpass.sh'))
+  readonly runSummary_md = path.join(this.workspace.value, 'run-summary.md')
 
   constructor(
     private readonly logger: Logger,

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -22,7 +22,7 @@ export class Workspace {
   readonly repos_md = mandatory(path.join(this.directory, 'repos.md'))
   readonly app_pem = mandatory(path.join(this.directory, 'app.pem'))
   readonly askpass_sh = mandatory(path.join(this.directory, 'askpass.sh'))
-  readonly runSummary_md = path.join(this.workspace.value, 'run-summary.md')
+  readonly runSummary_md: string = path.join(this.workspace.value, 'run-summary.md')
 
   constructor(
     private readonly logger: Logger,


### PR DESCRIPTION
This is the complementary PR for https://github.com/scala-steward-org/scala-steward/pull/3071.

While that PR _creates_ the summary report, this is the PR that links up to GitHub's [`core.summary`](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#:~:text=core.summary ) workflow command (as suggested by @alejandrohdezma in https://github.com/scala-steward-org/scala-steward/pull/3071#pullrequestreview-1466649042), to _display_ the report in [GitHub's Job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/#:~:text=core.summary).

In this change, if the `run-summary.md` file generated by the Scala Steward JVM process is found, it's written to the GitHub  summary - if it's not found, that's not regarded as an error, tolerating older Scala Steward versions if they're being used.