### PR TITLE
Don't persist the `run-summary.md` file beyond its own run

### DIFF
--- a/src/modules/workspace.test.ts
+++ b/src/modules/workspace.test.ts
@@ -182,6 +182,7 @@ test('`Workspace.saveWorkspaceCache()` → saves cache', async t => {
   const expected: string[] = [
     'rmRF("/home/scala-steward/workspace/store/refresh_error")',
     'rmRF("/home/scala-steward/workspace/repos")',
+    'rmRF("/home/scala-steward/workspace/run-summary.md")',
     'readFileSync("/home/scala-steward/repos.md")',
     `saveCache([/home/scala-steward/workspace], "scala-steward-acc000fd-${now}")`,
   ]

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -72,7 +72,9 @@ export class Workspace {
       // We don't want to keep `workspace/store/refresh_error` nor `workspace/repos` in the cache.
       await this.files.rmRF(path.join(this.workspace.value, 'store', 'refresh_error'))
       await this.files.rmRF(path.join(this.workspace.value, 'repos'))
-      await this.files.rmRF(this.runSummary_md) // don't persist a summary that's specific to this run
+
+      // Don't persist a summary that's specific to this run
+      await this.files.rmRF(this.runSummary_md)
 
       const hash = this.hashFile(this.repos_md.value)
 

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -72,6 +72,7 @@ export class Workspace {
       // We don't want to keep `workspace/store/refresh_error` nor `workspace/repos` in the cache.
       await this.files.rmRF(path.join(this.workspace.value, 'store', 'refresh_error'))
       await this.files.rmRF(path.join(this.workspace.value, 'repos'))
+      await this.files.rmRF(this.runSummary_md) // don't persist a summary that's specific to this run
 
       const hash = this.hashFile(this.repos_md.value)
 


### PR DESCRIPTION
This was something we missed from https://github.com/scala-steward-org/scala-steward-action/pull/502 - because the `run-summary.md` file (introduced by https://github.com/scala-steward-org/scala-steward/pull/3071) is saved to the Scala Steward workspace, and almost the entire workspace is persisted to cache by Scala Steward's GitHub Action, the report would be persisted until the _next_ run of the GitHub Action.

Conceivably, if the next run went wrong somehow and didn't overwrite the old file, the _old_ summary could get reported against the subsequent run, which would be bad.

The fix here is to delete the summary at the `saveWorkspaceCache()` step, which occurs after the summary has been transferred to the `GITHUB_STEP_SUMMARY` file by calling `core.summary()`.