### PR TITLE
Add link to docs on how to run locally to attach a JVM debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ By default, Scala Steward will ignore "opts" files (such as `.jvmopts` or `.sbto
 <br/>
 </details>
 
-<details><summary><b>Run Scala Steward in debug mode</b></summary><br/>
+<details><summary><b>Run Scala Steward with step debug logging</b></summary><br/>
 
 You just need to enable [GitHub Actions' "step debug logging"](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) and Scala Steward will start automatically in debug mode too.
 
@@ -442,6 +442,17 @@ For this you must set the following secret in the repository that contains the w
 
 <br/>
 </details>
+
+<details><summary><b>Running locally to attach a JVM debugger</b></summary><br/>
+
+When debugging the behaviour of Scala Steward, it can be helpful to run Scala Steward
+locally, while mimicking the settings used by the Scala Steward GitHub Action, so that
+a debugger can be attached - [the Guardian have notes on how they do that](https://github.com/guardian/scala-steward-public-repos/blob/main/running-locally.md),
+which may provide a helpful example if you need to do that in your own organisation. 
+
+<br/>
+</details>
+
 
 <details><summary><b>Using the default GitHub Action Token (instead of the GitHub App)</b></summary><br/>
 


### PR DESCRIPTION
When debugging the behaviour of Scala Steward in production, it can be helpful to run Scala Steward locally, while **mimicking the settings used by the Scala Steward GitHub Action**, so that a debugger can be attached - here's a link to some docs we wrote at the Guardian on this, which may be helpful to others:

https://github.com/guardian/scala-steward-public-repos/blob/main/running-locally.md