### PR TITLE
use github API URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: |
       The URL of the GitHub API, only use this input if
       you are using GitHub Enterprise.
-    default: https://api.github.com
+    default: ${{ github.api_url }}
     required: false
   github-app-auth-only:
     description: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@actions/io": "^1.1.3",
         "@actions/tool-cache": "^2.0.1",
         "@octokit/auth-app": "^4.0.9",
+        "@octokit/request": "^6.0.0",
         "@types/node-fetch": "^2.6.4",
         "@types/sinon": "^10.0.13",
         "jssha": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
     "@octokit/auth-app": "^4.0.9",
+    "@octokit/request": "^6.0.0",
     "@types/node-fetch": "^2.6.4",
     "@types/sinon": "^10.0.13",
     "jssha": "^3.3.0",

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -6,6 +6,7 @@ import * as core from '@actions/core'
 import {getOctokit} from '@actions/github'
 import * as io from '@actions/io'
 import {createAppAuth} from '@octokit/auth-app'
+import {request} from '@octokit/request'
 import {type Files} from '../core/files'
 import {type Logger} from '../core/logger'
 import {nonEmpty, NonEmptyString} from '../core/types'
@@ -26,13 +27,13 @@ async function run(): Promise<void> {
     const logger: Logger = core
     const files: Files = {...fs, ...io}
     const inputs = Input.from(core, files, logger).all()
-    const gitHubToken = await gitHubAppToken(inputs.github.app, 'installation') ?? inputs.github.token.value
     const gitHubApiUrl = inputs.github.apiUrl.value
+    const gitHubToken = await gitHubAppToken(inputs.github.app, gitHubApiUrl, 'installation') ?? inputs.github.token.value
     const octokit = getOctokit(gitHubToken, {baseUrl: gitHubApiUrl})
     const github = GitHub.from(logger, octokit)
     const workspace = Workspace.from(logger, files, os, cache)
 
-    const user = await gitHubAppToken(inputs.github.app, 'app')
+    const user = await gitHubAppToken(inputs.github.app, gitHubApiUrl, 'app')
       .then(appToken => appToken ? getOctokit(appToken, {baseUrl: gitHubApiUrl}) : undefined)
       .then(async octokit => octokit ? octokit.rest.apps.getAuthenticated() : undefined)
       .then(async response => response ? github.getAppUser(response.data.slug) : github.getAuthUser())
@@ -91,15 +92,22 @@ async function run(): Promise<void> {
  * Returns a GitHub App Token.
  *
  * @param app The GitHub App information.
+ * @param gitHubApiUrl The GitHub API URL.
  * @param type The type of token to retrieve, either `app` or `installation`.
  * @returns the GitHub App Token for the provided installation.
  */
-async function gitHubAppToken(app: GitHubAppInfo | undefined, type: 'app' | 'installation') {
+async function gitHubAppToken(app: GitHubAppInfo | undefined, gitHubApiUrl: string, type: 'app' | 'installation') {
   if (!app) {
     return undefined
   }
 
-  const auth = createAppAuth({appId: app.id.value, privateKey: app.key.value})
+  const auth = createAppAuth({
+    appId: app.id.value,
+    privateKey: app.key.value,
+    request: request.defaults({
+      baseUrl: gitHubApiUrl,
+    }),
+  })
 
   const response = type === 'app'
     ? await auth({type: 'app'})

--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -171,7 +171,7 @@ export class Input {
     const authOnly = this.inputs.getBooleanInput('github-app-auth-only')
     const id = nonEmpty(this.inputs.getInput('github-app-id'))
     const installation = nonEmpty(this.inputs.getInput('github-app-installation-id'))
-    const key = nonEmpty(this.inputs.getInput('github-app-key'))
+    const key = nonEmpty(this.inputs.getInput('github-app-key')?.replace(/\\n/g, '\n'))
 
     if (!id && !key) {
       return undefined


### PR DESCRIPTION
* use the given URL to get tokens
* use the variable `github.api_url` as default value (https://docs.github.com/en/actions/learn-github-actions/contexts)

Fixes the secretOrPrivateKey must be an asymmetric key error
using the workaround from https://github.com/octokit/auth-app.js/issues/465#issuecomment-1549150080

fixes: #517
closes: #521