### PR TITLE
Convert multiple env into single line as expected from JWT lib

### DIFF
--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -171,7 +171,7 @@ export class Input {
     const authOnly = this.inputs.getBooleanInput('github-app-auth-only')
     const id = nonEmpty(this.inputs.getInput('github-app-id'))
     const installation = nonEmpty(this.inputs.getInput('github-app-installation-id'))
-    const key = nonEmpty(this.inputs.getInput('github-app-key'))
+    const key = nonEmpty(this.inputs.getInput('github-app-key')?.replace(/\\n/g, '\n'))
 
     if (!id && !key) {
       return undefined


### PR DESCRIPTION
Fixes the `secretOrPrivateKey must be an asymmetric key` error
using the workaround from https://github.com/octokit/auth-app.js/issues/465#issuecomment-1549150080