### PR TITLE
Add support for setting Coursier's --extra-jars option when launching Scala Steward

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,11 @@ inputs:
       Url to download the coursier linux CLI from.
     default: https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz
     required: false
+  extra-jars:
+    description: |
+      Extra JARs to be added to the classpath of the
+      launched application. Directories accepted too.
+    required: false
   github-api-url:
     description: |
       The URL of the GitHub API, only use this input if

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -74,7 +74,7 @@ async function run(): Promise<void> {
       '--do-not-fork',
       '--disable-sandbox',
       inputs.steward.extraArgs?.value.split(' ') ?? [],
-    ])
+    ], inputs.steward.extraJars)
 
     if (files.existsSync(workspace.runSummary_md)) {
       logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -65,10 +65,12 @@ export async function install(): Promise<void> {
  *
  * @param app - The application to launch
  * @param arguments_ - The args to pass to the application launcher.
+ * @param extraJars - Extra JARs to be added to the classpath of the launched application. Directories accepted too.
  */
 export async function launch(
   app: string,
   arguments_: Array<string | string[]> = [],
+  extraJars: NonEmptyString | undefined,
 ): Promise<void> {
   core.startGroup(`Launching ${app}`)
 
@@ -78,6 +80,7 @@ export async function launch(
     '-r',
     'sonatype:snapshots',
     app,
+     ...(extraJars ? ['--extra-jars', extraJars.value] : []),
     '--',
     ...arguments_.flatMap((argument: string | string[]) => (typeof argument === 'string' ? [argument] : argument)),
   ]

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -70,7 +70,7 @@ export async function install(): Promise<void> {
 export async function launch(
   app: string,
   arguments_: Array<string | string[]> = [],
-  extraJars: NonEmptyString | undefined,
+  extraJars: NonEmptyString | undefined = undefined,
 ): Promise<void> {
   core.startGroup(`Launching ${app}`)
 
@@ -80,7 +80,7 @@ export async function launch(
     '-r',
     'sonatype:snapshots',
     app,
-     ...(extraJars ? ['--extra-jars', extraJars.value] : []),
+    ...(extraJars ? ['--extra-jars', extraJars.value] : []),
     '--',
     ...arguments_.flatMap((argument: string | string[]) => (typeof argument === 'string' ? [argument] : argument)),
   ]

--- a/src/modules/input.test.ts
+++ b/src/modules/input.test.ts
@@ -23,6 +23,7 @@ test('`Input.all` → returns all inputs', t => {
     .with('scalafix-migrations', () => '.github/scalafix-migrations.conf')
     .with('other-args', () => '--help')
     .with('signing-key', () => '42')
+    .with('extra-jars', () => 'path/to/my/jars')
     .otherwise(() => '')
 
   const booleanInputs = (name: string) => match(name)
@@ -56,6 +57,7 @@ test('`Input.all` → returns all inputs', t => {
       timeout: nonEmpty('60s'),
       ignoreOptsFiles: true,
       extraArgs: nonEmpty('--help'),
+      extraJars: nonEmpty('path/to/my/jars'),
     },
     migrations: {
       scalafix: nonEmpty('.github/scalafix-migrations.conf'),

--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -47,6 +47,7 @@ export class Input {
         timeout: nonEmpty(this.inputs.getInput('timeout')),
         ignoreOptsFiles: this.inputs.getBooleanInput('ignore-opts-files'),
         extraArgs: nonEmpty(this.inputs.getInput('other-args')),
+        extraJars: nonEmpty(this.inputs.getInput('extra-jars')),
       },
       migrations: {
         scalafix: nonEmpty(this.inputs.getInput('scalafix-migrations')),


### PR DESCRIPTION
copy of #467 

tested with released version from my fork, successfully integrated with google cloud artifact registry with:

```
      - name: Fetch gar-coursier
        id: fetch_gar_coursier
        run: |
          export GAR_COURSIER_CLASSPATH=$(cs fetch --classpath "dev.rolang:gar-coursier_2.13:0.1.3");
          echo "GAR_COURSIER_CLASSPATH=$GAR_COURSIER_CLASSPATH" >> $GITHUB_ENV;
          
      - name: Launch Scala Steward
        uses: lgmyrek/scala-steward-action@v2
        with:
          ...
          extra-jars: ${{ env.GAR_COURSIER_CLASSPATH }}
          cache-ttl: 0minute
```