### PR TITLE
Refresh token every 50 minutes

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -28,8 +28,8 @@ async function run(): Promise<void> {
     const files: Files = {...fs, ...io}
     const inputs = Input.from(core, files, logger).all()
     const gitHubApiUrl = inputs.github.apiUrl.value
-    const gitHubToken = await gitHubAppToken(inputs.github.app, gitHubApiUrl, 'installation') ?? inputs.github.token.value
-    const octokit = getOctokit(gitHubToken, {baseUrl: gitHubApiUrl})
+    const gitHubToken = async () => await gitHubAppToken(inputs.github.app, gitHubApiUrl, 'installation') ?? inputs.github.token.value
+    const octokit = getOctokit(await gitHubToken(), {baseUrl: gitHubApiUrl})
     const github = GitHub.from(logger, octokit)
     const workspace = Workspace.from(logger, files, os, cache)
 
@@ -114,7 +114,7 @@ async function gitHubAppToken(app: GitHubAppInfo | undefined, gitHubApiUrl: stri
 
   const response = type === 'app'
     ? await auth({type: 'app'})
-    : (app.installation ? await auth({type: 'installation', installationId: app.installation.value}) : undefined)
+    : (app.installation ? await auth({type: 'installation', installationId: app.installation.value, refresh: true}) : undefined)
 
   return response?.token
 }

--- a/src/modules/workspace.test.ts
+++ b/src/modules/workspace.test.ts
@@ -58,7 +58,7 @@ test.after(() => {
 test('`Workspace.prepare()` → prepares the workspace', async t => {
   const {workspace, calls} = fixture()
 
-  await workspace.prepare('- owner/repo1\n- owner/repo2', '123', undefined)
+  await workspace.prepare('- owner/repo1\n- owner/repo2', async () => '123', undefined)
 
   const expected: string[] = [
     'mkdirP("/home/scala-steward")',
@@ -80,7 +80,7 @@ test('`Workspace.prepare()` → prepares the workspace when using a GitHub App',
     key: mandatory('this-is-the-key'),
   }
 
-  await workspace.prepare('this will not be used', '123', gitHubAppInfo)
+  await workspace.prepare('this will not be used', async () => '123', gitHubAppInfo)
 
   const expected: string[] = [
     'mkdirP("/home/scala-steward")',
@@ -103,13 +103,25 @@ test('`Workspace.prepare()` → uses the repos input when GitHub App is "auth on
     key: mandatory('this-is-the-key'),
   }
 
-  await workspace.prepare('- owner/repo', '123', gitHubAppInfo)
+  await workspace.prepare('- owner/repo', async () => '123', gitHubAppInfo)
 
   const expected: string[] = [
     'mkdirP("/home/scala-steward")',
     'writeFileSync("/home/scala-steward/repos.md", "- owner/repo")',
     'writeFileSync("/home/scala-steward/askpass.sh", "#!/bin/sh\n\necho \'123\'")',
     'chmodSync("/home/scala-steward/askpass.sh", 493)',
+  ]
+
+  t.deepEqual(calls, expected)
+})
+
+test('`Workspace.writeAskPass()` → writes a token to the askpass.sh', async t => {
+  const {workspace, calls} = fixture()
+
+  await workspace.writeAskPass(async () => '123')
+
+  const expected: string[] = [
+    'writeFileSync("/home/scala-steward/askpass.sh", "#!/bin/sh\n\necho \'123\'")',
   ]
 
   t.deepEqual(calls, expected)
@@ -189,4 +201,3 @@ test('`Workspace.saveWorkspaceCache()` → saves cache', async t => {
 
   t.deepEqual(calls, expected)
 })
-


### PR DESCRIPTION
Fixed https://github.com/scala-steward-org/scala-steward-action/issues/625

`--git-ask-pass` file is now updated every 50 minutes, as the default token expiration is 1 hour

![image](https://github.com/user-attachments/assets/a007686f-6a62-4849-ac7d-dbc80d33da39)


And workflow can now run longer than one hour with no issues

<img width="845" alt="image" src="https://github.com/user-attachments/assets/34fce759-8cd3-4f2c-b6b0-05dcc84159f1">
