### PR TITLE
Fix README.md to run on ubuntu-latest and install sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,7 @@ jobs:
     name: Scala Steward
     steps:
       - name: Install sbt
-        run: |
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-          sudo apt-get update
-          sudo apt-get install sbt
+        uses: sbt/setup-sbt@v1
       - name: Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
 ```
@@ -140,12 +135,7 @@ jobs:
     name: Launch Scala Steward
     steps:
       - name: Install sbt
-        run: |
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-          sudo apt-get update
-          sudo apt-get install sbt
+        uses: sbt/setup-sbt@v1
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:
@@ -344,12 +334,7 @@ You can manually trigger workflow runs using the [workflow_dispatch](https://doc
      name: Launch Scala Steward
      steps:
        - name: Install sbt
-         run: |
-           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-           curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-           sudo apt-get update
-           sudo apt-get install sbt
+         uses: sbt/setup-sbt@v1
        - name: Launch Scala Steward
          uses: scala-steward-org/scala-steward-action@v2
          with:
@@ -408,12 +393,7 @@ When using the `github-app-*` inputs, Scala Steward will always retrieve the lis
      name: Launch Scala Steward
      steps:
        - name: Install sbt
-         run: |
-           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-           curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-           sudo apt-get update
-           sudo apt-get install sbt
+         uses: sbt/setup-sbt@v1
        - name: Launch Scala Steward
          uses: scala-steward-org/scala-steward-action@v2
          with:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ permissions:
 
 jobs:
   scala-steward:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Scala Steward
     steps:
+      - name: Install sbt
+        run: |
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          sudo apt-get update
+          sudo apt-get install sbt
       - name: Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
 ```
@@ -129,9 +136,16 @@ name: Launch Scala Steward
 
 jobs:
   scala-steward:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Launch Scala Steward
     steps:
+      - name: Install sbt
+        run: |
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          sudo apt-get update
+          sudo apt-get install sbt
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:
@@ -329,6 +343,13 @@ You can manually trigger workflow runs using the [workflow_dispatch](https://doc
      runs-on: ubuntu-latest
      name: Launch Scala Steward
      steps:
+       - name: Install sbt
+         run: |
+           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+           curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+           sudo apt-get update
+           sudo apt-get install sbt
        - name: Launch Scala Steward
          uses: scala-steward-org/scala-steward-action@v2
          with:
@@ -386,6 +407,13 @@ When using the `github-app-*` inputs, Scala Steward will always retrieve the lis
      runs-on: ubuntu-latest
      name: Launch Scala Steward
      steps:
+       - name: Install sbt
+         run: |
+           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+           curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+           sudo apt-get update
+           sudo apt-get install sbt
        - name: Launch Scala Steward
          uses: scala-steward-org/scala-steward-action@v2
          with:


### PR DESCRIPTION
`ubuntu-latest` or `ubuntu-22.04` runner tags are used on README.md. I think it is better that only `ubuntu-latest` is documented. But `sbt` was removed from the `ubuntu-latest` (equals `ubuntu-24.04`) runner image.  https://github.com/actions/runner-images/issues/10636

This PR makes a README.md fix to run on `ubuntu-latest` and install `sbt`. Thanks!