### PR TITLE
Fix loss of `run-summary.md` in GHA Job Summary

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -76,16 +76,16 @@ async function run(): Promise<void> {
         '--disable-sandbox',
         inputs.steward.extraArgs?.value.split(' ') ?? [],
       ], inputs.steward.extraJars)
+
+      if (files.existsSync(workspace.runSummary_md)) {
+        logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
+
+        const summaryMarkdown = files.readFileSync(workspace.runSummary_md, 'utf8')
+        await core.summary.addRaw(summaryMarkdown).write()
+      }
     } finally {
-      await workspace.saveWorkspaceCache()
+      await workspace.purgeTempFilesAndSaveCache()
       await workspace.cancelTokenRefresh()
-    }
-
-    if (files.existsSync(workspace.runSummary_md)) {
-      logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
-
-      const summaryMarkdown = files.readFileSync(workspace.runSummary_md, 'utf8')
-      await core.summary.addRaw(summaryMarkdown).write()
     }
   } catch (error: unknown) {
     core.setFailed(` ✕ ${(error as Error).message}`)

--- a/src/modules/workspace.test.ts
+++ b/src/modules/workspace.test.ts
@@ -187,7 +187,7 @@ test('`Workspace.restoreWorkspaceCache()` → generates different hash for diffe
 test('`Workspace.saveWorkspaceCache()` → saves cache', async t => {
   const {workspace, calls} = fixture('- owner/repo')
 
-  await workspace.saveWorkspaceCache()
+  await workspace.purgeTempFilesAndSaveCache()
 
   const now = Date.now()
 

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -74,7 +74,7 @@ export class Workspace {
    *
    * @param {string} workspace - the Scala Steward workspace directory
    */
-  async saveWorkspaceCache(): Promise<void> {
+  async purgeTempFilesAndSaveCache(): Promise<void> {
     try {
       this.logger.startGroup('Saving workspace to cache...')
 


### PR DESCRIPTION
Scala Steward's GitHub Action Job Summary, which reports success or failure of individual repos in the Scala Steward run, was added with https://github.com/scala-steward-org/scala-steward/pull/3071 in June 2023, followed up by https://github.com/scala-steward-org/scala-steward/pull/3088, which ensured that old `run-summary.md` files couldn't persist in the workspace cache (where they might become misleading), by purging them before the cache was saved.

Unfortunately https://github.com/scala-steward-org/scala-steward-action/pull/631 (released with [v2.67.0](https://github.com/scala-steward-org/scala-steward-action/releases/tag/v2.67.0) in September 2024) unintentionally broke the outputting of the Job Summary, because it [moved](https://github.com/scala-steward-org/scala-steward-action/pull/631/files#r1825912103) the `saveWorkspaceCache()` call (which among other things deletes the `run-summary.md` file) to a point _before_ the `run-summary.md` file was _read_ and output to the GitHub Action Job Summary.

We can see this in these two successive runs of the Guardian's Scala Steward workflow:

* Run **6002** (using scala-steward-action@**v2.65.0**) successfully output the scala-steward summary: https://github.com/guardian/scala-steward-public-repos/actions/runs/11591772739 https://github.com/guardian/scala-steward-public-repos/actions/runs/11591772739/job/32272232470#step:7:451
![image](https://github.com/user-attachments/assets/d975b917-92cc-4932-931d-88838662999e)

* Run **6003** (using scala-steward-action@**v2.70.0**) silently omitted the summary: https://github.com/guardian/scala-steward-public-repos/actions/runs/11592668893 https://github.com/guardian/scala-steward-public-repos/actions/runs/11592668893/job/32275051343#step:7:35 
![image](https://github.com/user-attachments/assets/50ef06da-913d-4dd0-b39f-63b6519528a7)


### Changes

The fix is just to move the code processing the run-summary earlier, to _before_ the new `finally` block introduced by #631 which executes `saveWorkspaceCache()`.

I've also renamed the method to make its actions a little clearer:

```typescript
workspace.saveWorkspaceCache()
```

...becomes...

```typescript
workspace.purgeTempFilesAndSaveCache()
```

#### Tests

Without refactoring, testing that the `core.summary.addRaw()` method is successfully called with a summary would probably require some kind of large test against `run()` in `main.ts` - there are none of those already, and I was too nervous to attempt one!

I have [run](https://github.com/guardian/scala-steward-public-repos/actions/runs/11629578991) the `scala-steward-org/scala-steward-action@snapshots/652` snapshot of this PR with https://github.com/guardian/scala-steward-public-repos/pull/78, and confirmed that the report is properly restored to the Job Summary:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9d94c06d-e152-46b2-a568-0a4d4006042e">
