### PR TITLE
Update Mill to 0.12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ When it launches it will send PR to update all the repos selected in step (2.2).
     # Steward will still respect the version specified in
     # your repository while updating it.
     #
-    # Default: 0.10.9
+    # Default: 0.12.5
     mill-version: ''
 
     # Other Scala Steward arguments not yet supported by

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ inputs:
       just affect the global `mill` executable. Scala 
       Steward will still respect the version specified in
       your repository while updating it.
-    default: "0.10.9"
+    default: "0.12.5"
     required: false
   other-args:
     description: |


### PR DESCRIPTION
This updates Mill to the latest version. This version is now a script that is able to run different Mill versions depending on the version set in project-specific `.mill-version` files.