### PR TITLE
Output Run Summary even if Scala Steward exits with failure code

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -76,14 +76,14 @@ async function run(): Promise<void> {
         '--disable-sandbox',
         inputs.steward.extraArgs?.value.split(' ') ?? [],
       ], inputs.steward.extraJars)
-
+    } finally {
       if (files.existsSync(workspace.runSummary_md)) {
         logger.info(`✓ Run Summary file: ${workspace.runSummary_md}`)
 
         const summaryMarkdown = files.readFileSync(workspace.runSummary_md, 'utf8')
         await core.summary.addRaw(summaryMarkdown).write()
       }
-    } finally {
+
       await workspace.purgeTempFilesAndSaveCache()
       await workspace.cancelTokenRefresh()
     }


### PR DESCRIPTION
Scala Steward's GitHub Action Job Summary, which reports success or failure of individual repos in the Scala Steward run, was added with https://github.com/scala-steward-org/scala-steward/pull/3071 in June 2023, but unfortunately, the Summary is currently _not_ output if Scala Steward exits with a failure code - which is the time when it would be most useful to see a summary of which repos succeeded or failed!

This was due to the summary-outputting code being placed _inside_ the `try` block, immediately after the call to `coursier.launch()` that runs Scala Steward - and `coursier.launch()` throws an error if the exit-code is non-zero (by default, Scala Steward exits with a non-zero exit code if _any_ repo fails, even when all other repos are successfully processed):

https://github.com/scala-steward-org/scala-steward-action/blob/2d41fa7534736e82e8bf4ed4e9d8ff40a33fcee3/src/modules/coursier.ts#L98-L100

...so the summary-outputting never occurs when a single repo fails.

This PR fixes that by placing the summary-outputting code into the `finally` block - so, as long as a summary file is generated, we'll get to see it:


#### Before

<img width="1916" height="845" alt="image" src="https://github.com/user-attachments/assets/bf5fcb87-01fe-4170-afdc-e8a523cb7435" />

#### After

<img width="1896" height="1029" alt="image" src="https://github.com/user-attachments/assets/5dff748b-70cd-47a2-8076-fcf3a096d117" />

This really is **so much better** for tracking down problem repos in a big org!

## See also

* https://github.com/scala-steward-org/scala-steward-action/pull/652
