### PR TITLE
Select Scala 2.13 or Scala 3 artifact based on Scala Steward version

### DIFF
--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -13,6 +13,7 @@ import {nonEmpty, NonEmptyString} from '../core/types'
 import * as coursier from '../modules/coursier'
 import {GitHub} from '../modules/github'
 import {Input, type GitHubAppInfo} from '../modules/input'
+import {scalaVersion} from '../core/scala-steward'
 import {Workspace} from '../modules/workspace'
 
 /**
@@ -48,7 +49,7 @@ async function run(): Promise<void> {
     }
 
     const app = inputs.steward.version
-      ? `org.scala-steward:scala-steward-core_3:${inputs.steward.version.value}`
+      ? `org.scala-steward:scala-steward-core_${scalaVersion(inputs.steward.version.value)}:${inputs.steward.version.value}`
       : 'scala-steward'
 
     try {

--- a/src/core/scala-steward.test.ts
+++ b/src/core/scala-steward.test.ts
@@ -1,0 +1,24 @@
+import test from 'ava'
+import {scalaVersion} from './scala-steward'
+
+test('`scalaVersion` → returns `2.13` for versions older than 0.33.0', t => {
+  t.is(scalaVersion('0.30.2'), '2.13')
+  t.is(scalaVersion('0.32.9'), '2.13')
+  t.is(scalaVersion('0.32.0'), '2.13')
+  t.is(scalaVersion('0.1.0'), '2.13')
+})
+
+test('`scalaVersion` → returns `3` for version 0.33.0', t => {
+  t.is(scalaVersion('0.33.0'), '3')
+})
+
+test('`scalaVersion` → returns `3` for versions newer than 0.33.0', t => {
+  t.is(scalaVersion('0.33.1'), '3')
+  t.is(scalaVersion('0.34.0'), '3')
+  t.is(scalaVersion('0.37.0'), '3')
+})
+
+test('`scalaVersion` → returns `3` for major versions greater than 0', t => {
+  t.is(scalaVersion('1.0.0'), '3')
+  t.is(scalaVersion('2.0.0'), '3')
+})

--- a/src/core/scala-steward.ts
+++ b/src/core/scala-steward.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns the Scala version suffix for the Scala Steward artifact.
+ *
+ * Scala Steward started publishing Scala 3 artifacts from version 0.33.0.
+ * Older versions only have Scala 2.13 artifacts.
+ *
+ * @param version The Scala Steward version string (e.g. "0.33.0").
+ * @returns "3" for versions >= 0.33.0, "2.13" otherwise.
+ */
+export function scalaVersion(version: string): string {
+  const parts = version.split('.').map(Number)
+  const [major = 0, minor = 0] = parts
+
+  if (major > 0 || minor >= 33) {
+    return '3'
+  }
+
+  return '2.13'
+}


### PR DESCRIPTION
PR #759 changed the artifact from `scala-steward-core_2.13` to `scala-steward-core_3`, breaking users who pin `scala-steward-version` to versions older than 0.33.0 since those versions only published `_2.13` artifacts. This adds a `scalaVersion` helper that returns `"3"` for versions >= 0.33.0 and `"2.13"` for older versions, using it when building the Coursier app coordinate.

Fixes #770