### PR TITLE
Drop defunct `sonatype:snapshots`, use `central:maven-snapshots`

### DIFF
--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -80,7 +80,7 @@ export async function launch(
     'launch',
     '--contrib',
     '-r',
-    'sonatype:snapshots',
+    'central:maven-snapshots',
     app,
     ...(extraJars ? ['--extra-jars', extraJars.value] : []),
     '--',


### PR DESCRIPTION
Scala Steward publishes `main` branch artifacts as `SNAPSHOT` artifacts - so if I want to try out this `main` branch build (triggered after https://github.com/scala-steward-org/scala-steward/pull/3804 was merged):

https://github.com/scala-steward-org/scala-steward/actions/runs/22737111661/job/65941869704#step:14:47

...without doing a full Scala Steward release, I need to launch Scala Steward version `0.37.2-49-ec21d0d9-SNAPSHOT`.

However, `scala-steward-action` is currently telling to `cs` to look in the  [defunct Sonatype OSSRH](https://central.sonatype.org/pages/ossrh-eol/) artifact repository for snapshot Scala Steward artifacts, and that repository just isn't there any more - Coursier will not find the artifact using `--contrib -r sonatype:snapshots` as it's currently invoked by `scala-steward-action`:

```
% cs launch --contrib -r sonatype:snapshots org.scala-steward:scala-steward-core_2.13:0.37.2-49-ec21d0d9-SNAPSHOT
Exception in thread "main" java.util.concurrent.CompletionException: coursier.cli.resolve.ResolveException: Resolution error: Error downloading org.scala-steward:scala-steward-core_2.13:0.37.2-49-ec21d0d9-SNAPSHOT
  not found: /Users/roberto_tyley/.ivy2/local/org.scala-steward/scala-steward-core_2.13/0.37.2-49-ec21d0d9-SNAPSHOT/ivys/ivy.xml
  not found: https://repo1.maven.org/maven2/org/scala-steward/scala-steward-core_2.13/0.37.2-49-ec21d0d9-SNAPSHOT/scala-steward-core_2.13-0.37.2-49-ec21d0d9-SNAPSHOT.pom
  not found: https://oss.sonatype.org/content/repositories/snapshots/org/scala-steward/scala-steward-core_2.13/0.37.2-49-ec21d0d9-SNAPSHOT/scala-steward-core_2.13-0.37.2-49-ec21d0d9-SNAPSHOT.pom
	at coursier.util.PlatformTaskCompanion$PlatformTaskOps.unsafeRun(PlatformTaskCompanion.scala:49)
```

## The fix: `central:maven-snapshots`

Coursier added support for the [new home](https://central.sonatype.org/publish/publish-portal-snapshots/) of SNAPSHOT releases with this PR (available in `cs` [v2.1.25-M20](https://github.com/coursier/coursier/releases/tag/v2.1.25-M20) and above):

* https://github.com/coursier/coursier/pull/3504

```
% cs launch --contrib -r central:maven-snapshots org.scala-steward:scala-steward-core_2.13:0.37.2-49-ec21d0d9-SNAPSHOT
Missing expected flag --forge-login, or command (validate-repo-config)!

Usage:
    scala-steward --workspace ....
```