### PR TITLE
feat: Allow pinning managed tool versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ When it launches it will send PR to update all the repos selected in step (2.2).
     # will use the last one published.
     scala-steward-version: ''
 
+    # Scalafmt version to install. If not provided, Coursier
+    # will install the default version from its app descriptor.
+    scalafmt-version: ''
+
     # Scalafix rules for version updates to run after
     # certain updates.
     # 
@@ -317,6 +321,14 @@ When it launches it will send PR to update all the repos selected in step (2.2).
     #
     # Default: ch.epfl.scala:scalafix-cli_2.13.18:0.14.6
     scalafix-dependency: ''
+
+    # scala-cli version to install. If not provided, Coursier
+    # will install the default version from its app descriptor.
+    scala-cli-version: ''
+
+    # sbt version to install. If not provided, Coursier will
+    # install the default version from its app descriptor.
+    sbt-version: ''
 
     # Whether to sign commits or not.
     #

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ When it launches it will send PR to update all the repos selected in step (2.2).
     scala-steward-version: ''
 
     # Scalafmt version to install. If not provided, Coursier
-    # will install the default version from its app descriptor.
+    # will install the version selected by its app descriptor.
     scalafmt-version: ''
 
     # Scalafix rules for version updates to run after
@@ -323,11 +323,11 @@ When it launches it will send PR to update all the repos selected in step (2.2).
     scalafix-dependency: ''
 
     # scala-cli version to install. If not provided, Coursier
-    # will install the default version from its app descriptor.
+    # will install the version selected by its app descriptor.
     scala-cli-version: ''
 
     # sbt version to install. If not provided, Coursier will
-    # install the default version from its app descriptor.
+    # install the version selected by its app descriptor.
     sbt-version: ''
 
     # Whether to sign commits or not.

--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,11 @@ inputs:
       Scala Steward version to use. If not provided it
       will use the last one published.
     required: false
+  scalafmt-version:
+    description: |
+      Scalafmt version to install. If not provided, Coursier
+      will install the default version from its app descriptor.
+    required: false
   scalafix-migrations:
     description: |
       Scalafix rules for version updates to run after
@@ -179,6 +184,16 @@ inputs:
       the Scalafix executable. Override this if you need a Scalafix version with
       different runtime requirements (for example a JDK version) than the default.
     default: "ch.epfl.scala:scalafix-cli_2.13.18:0.14.6"
+    required: false
+  scala-cli-version:
+    description: |
+      scala-cli version to install. If not provided, Coursier
+      will install the default version from its app descriptor.
+    required: false
+  sbt-version:
+    description: |
+      sbt version to install. If not provided, Coursier will
+      install the default version from its app descriptor.
     required: false
   sign-commits:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ inputs:
   scalafmt-version:
     description: |
       Scalafmt version to install. If not provided, Coursier
-      will install the default version from its app descriptor.
+      will install the version selected by its app descriptor.
     required: false
   scalafix-migrations:
     description: |
@@ -188,12 +188,12 @@ inputs:
   scala-cli-version:
     description: |
       scala-cli version to install. If not provided, Coursier
-      will install the default version from its app descriptor.
+      will install the version selected by its app descriptor.
     required: false
   sbt-version:
     description: |
       sbt version to install. If not provided, Coursier will
-      install the default version from its app descriptor.
+      install the version selected by its app descriptor.
     required: false
   sign-commits:
     description: |

--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -51,6 +51,9 @@ export async function selfInstall(): Promise<void> {
  */
 export async function install(): Promise<void> {
   try {
+    const scalafmtInputVersion = core.getInput('scalafmt-version')
+    const scalaCliInputVersion = core.getInput('scala-cli-version')
+    const sbtInputVersion = core.getInput('sbt-version')
     const scalafixDependency = core.getInput('scalafix-dependency')
 
     core.debug(`Installing scalafix ${scalafixDependency}`)
@@ -60,7 +63,14 @@ export async function install(): Promise<void> {
 
     await exec.exec(
       'cs',
-      ['install', 'scalafmt', 'scala-cli', 'sbt', '--install-dir', binary],
+      [
+        'install',
+        versionedApp('scalafmt', scalafmtInputVersion),
+        versionedApp('scala-cli', scalaCliInputVersion),
+        versionedApp('sbt', sbtInputVersion),
+        '--install-dir',
+        binary,
+      ],
       {
         silent: true,
         listeners: {stdline: core.debug, errline: core.debug},
@@ -93,6 +103,10 @@ export async function install(): Promise<void> {
     core.debug(error instanceof Error ? error.message : String(error))
     throw new Error('Unable to install managed tools', {cause: error})
   }
+}
+
+export function versionedApp(app: string, version: string): string {
+  return version ? `${app}:${version}` : app
 }
 
 /**
@@ -163,4 +177,3 @@ export async function remove(): Promise<void> {
     listeners: {stdline: core.info, errline: core.debug},
   })
 }
-


### PR DESCRIPTION
## Summary
Adds optional inputs for pinning the versions of tools installed through Coursier:

- `scalafmt-version`
- `scala-cli-version`
- `sbt-version`

When these inputs are unset, the action keeps the current behavior and lets Coursier install versions selected by its app descriptors

## Motivation
Today the action installs `scalafmt`, `scala-cli`, and `sbt` without specifying versions. That keeps setup simple, but it also means a new upstream tool release can change what a workflow gets, even when the workflow file has not changed. These inputs give users a way to pin those tools when they need repeatable runs, while keeping the current behavior for everyone else

## Verification
- `npm run docs`
- `npm test`