### PR TITLE
fix: use cs bootstrap instead of cs install to respect COURSIER_REPOSITORIES

### DIFF
--- a/src/modules/coursier.ts
+++ b/src/modules/coursier.ts
@@ -47,6 +47,11 @@ export async function selfInstall(): Promise<void> {
  * `coursier`. Assumes `selfInstall()` has already put `cs` on the
  * `PATH`.
  *
+ * Uses `cs bootstrap` instead of `cs install` because `cs install`
+ * ignores COURSIER_REPOSITORIES when the app descriptor specifies its
+ * own repositories (see https://github.com/coursier/coursier/issues/2832).
+ * `cs bootstrap` with explicit Maven coordinates respects the env var.
+ *
  * Throws error if the installation fails.
  */
 export async function install(): Promise<void> {
@@ -56,44 +61,56 @@ export async function install(): Promise<void> {
     const sbtInputVersion = core.getInput('sbt-version')
     const scalafixDependency = core.getInput('scalafix-dependency')
 
-    core.debug(`Installing scalafix ${scalafixDependency}`)
-
     const binary = path.join(os.homedir(), '.local', 'bin')
     await io.mkdirP(binary)
 
+    const scalafmtVersion = scalafmtInputVersion || 'latest.stable'
+    core.debug(`Installing scalafmt ${scalafmtVersion}`)
     await exec.exec(
       'cs',
-      [
-        'install',
-        versionedApp('scalafmt', scalafmtInputVersion),
-        versionedApp('scala-cli', scalaCliInputVersion),
-        versionedApp('sbt', sbtInputVersion),
-        '--install-dir',
-        binary,
-      ],
+      ['bootstrap', `org.scalameta:scalafmt-cli_2.13:${scalafmtVersion}`, '--main', 'org.scalafmt.cli.Cli', '-o', path.join(binary, 'scalafmt')],
       {
         silent: true,
         listeners: {stdline: core.debug, errline: core.debug},
       },
     )
 
-    const scalafixBinaryPath = path.join(binary, 'scalafix')
-
+    core.debug(`Installing scalafix ${scalafixDependency}`)
     await exec.exec(
       'cs',
-      ['bootstrap', '--main', 'scalafix.cli.Cli', scalafixDependency, '-o', scalafixBinaryPath],
+      ['bootstrap', '--main', 'scalafix.cli.Cli', scalafixDependency, '-o', path.join(binary, 'scalafix')],
       {
         silent: true,
         listeners: {stdline: core.debug, errline: core.debug},
       },
     )
 
-    const scalafmtVersion = await execute('cs', 'launch', 'scalafmt', '--', '--version')
+    const sbtVersion = sbtInputVersion || 'latest.stable'
+    core.debug(`Installing sbt ${sbtVersion}`)
+    await exec.exec(
+      'cs',
+      ['bootstrap', `org.scala-sbt:sbt-launch:${sbtVersion}`, '--main', 'xsbt.boot.Boot', '-o', path.join(binary, 'sbt')],
+      {
+        silent: true,
+        listeners: {stdline: core.debug, errline: core.debug},
+      },
+    )
 
-    core.info(`✓ Scalafmt installed, version: ${scalafmtVersion.replace(/^scalafmt /v, '').trim()}`)
+    const scalaCliVersion = scalaCliInputVersion || 'latest.stable'
+    core.debug(`Installing scala-cli ${scalaCliVersion}`)
+    await exec.exec(
+      'cs',
+      ['bootstrap', `org.virtuslab.scala-cli:cli_3:${scalaCliVersion}`, '--main', 'scala.cli.ScalaCli', '-o', path.join(binary, 'scala-cli')],
+      {
+        silent: true,
+        listeners: {stdline: core.debug, errline: core.debug},
+      },
+    )
 
-    const scalafixVersion = await execute(scalafixBinaryPath, '--version')
+    const scalafmtOut = await execute(path.join(binary, 'scalafmt'), '--version')
+    core.info(`✓ Scalafmt installed, version: ${scalafmtOut.replace(/^scalafmt /v, '').trim()}`)
 
+    const scalafixVersion = await execute(path.join(binary, 'scalafix'), '--version')
     core.info(`✓ Scalafix installed, version: ${scalafixVersion.trim()}`)
 
     core.info('✓ SBT installed')
@@ -103,10 +120,6 @@ export async function install(): Promise<void> {
     core.debug(error instanceof Error ? error.message : String(error))
     throw new Error('Unable to install managed tools', {cause: error})
   }
-}
-
-export function versionedApp(app: string, version: string): string {
-  return version ? `${app}:${version}` : app
 }
 
 /**


### PR DESCRIPTION
## Summary

  Replaces `cs install` with `cs bootstrap` for managed tool installation (scalafmt, scalafix, sbt, scala-cli). This ensures `COURSIER_REPOSITORIES` is
  respected when resolving tool artifacts.

  ## Motivation

  `cs install` uses Coursier app descriptors which hardcode `"repositories": ["central"]` for dependency resolution, completely ignoring the
  `COURSIER_REPOSITORIES` environment variable. This causes "Unable to install managed tools" failures when CI runners cannot reach `repo1.maven.org` directly due to rate-limiting (HTTP 429)

More details in https://github.com/scala-steward-org/scala-steward-action/issues/836

## Changes

  - Replace single `cs install scalafmt scala-cli sbt` call with individual `cs bootstrap` calls using explicit Maven coordinates and main classes
  - Remove unused `versionedApp` helper function
  - Existing `scalafmt-version`, `scala-cli-version`, `sbt-version` inputs continue to work as before

## Verification

  - `npm test`