### PR TITLE
clean: replace jssha with the built-in node:crypto module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "@actions/tool-cache": "^4.0.0",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/request": "^10.0.8",
-        "@types/sinon": "^21.0.1",
-        "jssha": "^3.3.1"
+        "@types/sinon": "^21.0.1"
       },
       "devDependencies": {
         "@ava/typescript": "^7.0.0",
@@ -7096,14 +7095,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jssha": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
-      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "@actions/tool-cache": "^4.0.0",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/request": "^10.0.8",
-    "@types/sinon": "^21.0.1",
-    "jssha": "^3.3.1"
+    "@types/sinon": "^21.0.1"
   },
   "devDependencies": {
     "@ava/typescript": "^7.0.0",

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -1,5 +1,5 @@
+import {createHash} from 'node:crypto'
 import path from 'node:path'
-import jsSHA from 'jssha/dist/sha256'
 import {type ActionCache} from '../core/cache.js'
 import {type Files} from '../core/files.js'
 import {type Logger} from '../core/logger.js'
@@ -175,9 +175,7 @@ export class Workspace {
    * @returns {string} the file content's hash
    */
   private hashFile(file: string): string {
-    // eslint-disable-next-line unicorn/text-encoding-identifier-case, new-cap
-    const sha = new jsSHA('SHA-256', 'TEXT', {encoding: 'UTF8'})
-    sha.update(this.files.readFileSync(file, 'utf8'))
-    return sha.getHash('HEX').slice(0, 8)
+    const contents = this.files.readFileSync(file, 'utf8')
+    return createHash('sha256').update(contents, 'utf8').digest('hex').slice(0, 8)
   }
 }


### PR DESCRIPTION
# What
Drops the jssha dependency and computes the workspace cache hash with Node's built-in node:crypto instead.

# Why
Node has shipped SHA-256 hashing in node:crypto since long before this action's minimum supported version, so jssha was pulling in a third-party implementation of something already in the runtime.

This is the first of three PRs that move the action onto Node 24 built-ins, since GitHub Action now uses Node.js v24

# Cache keys are unchanged
The hash feeds the scala-steward-<hash>-<timestamp> cache key, so a changed value would silently invalidate every user's workspace cache. Output was compared against jssha for ASCII, embedded newlines and multi-byte UTF-8 inputs and is byte-for-byte identical. The existing tests assert the literal hashes acc000fd and fe470d28 and still pass unmodified.

# Verification
npm run all passes on Node 24.18.1. All 37 tests pass and the coverage report is unchanged.