### PR TITLE
refactor: rewrite parameter properties as explicit field assignments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@ava/typescript": "^7.0.0",
-        "@tsconfig/node20": "^20.1.9",
+        "@tsconfig/node24": "^24.0.4",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
         "@vercel/ncc": "^0.38.4",
@@ -1986,10 +1986,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^7.0.0",
-    "@tsconfig/node20": "^20.1.9",
+    "@tsconfig/node24": "^24.0.4",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
     "@vercel/ncc": "^0.38.4",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,11 @@ export class NonEmptyString {
     return (string === '') ? undefined : new NonEmptyString(string)
   }
 
-  private constructor(readonly value: string) {}
+  readonly value: string
+
+  private constructor(value: string) {
+    this.value = value
+  }
 }
 
 /**

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -25,10 +25,16 @@ export class GitHub {
     name: () => mandatory('github-actions[bot]'),
   }
 
+  private readonly logger: Logger
+  private readonly github: GitHubClient
+
   constructor(
-    private readonly logger: Logger,
-    private readonly github: GitHubClient,
-  ) {}
+    logger: Logger,
+    github: GitHubClient,
+  ) {
+    this.logger = logger
+    this.github = github
+  }
 
   /**
    * Returns the login, email and name of the authenticated user.

--- a/src/modules/healthcheck.ts
+++ b/src/modules/healthcheck.ts
@@ -10,7 +10,13 @@ export class HealthCheck {
     return new HealthCheck(logger, probe)
   }
 
-  constructor(private readonly logger: Logger, private readonly probe: ConnectivityProbe) {}
+  private readonly logger: Logger
+  private readonly probe: ConnectivityProbe
+
+  constructor(logger: Logger, probe: ConnectivityProbe) {
+    this.logger = logger
+    this.probe = probe
+  }
 
   /**
    * Checks connectivity to the configured Maven repositories. Throws if

--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -10,23 +10,36 @@ export type GitHubAppInfo = {
   key: NonEmptyString;
 }
 
+export type ActionInputs = {
+  getInput: (name: string) => string;
+  getBooleanInput: (name: string) => boolean;
+}
+
 /**
  * Retrieves (and sanitize) inputs.
  */
 export class Input {
   static from(
-    inputs: {getInput: (name: string) => string; getBooleanInput: (name: string) => boolean},
+    inputs: ActionInputs,
     files: Files,
     logger: Logger,
   ) {
     return new Input(inputs, files, logger)
   }
 
+  private readonly inputs: ActionInputs
+  private readonly files: Files
+  private readonly logger: Logger
+
   constructor(
-    private readonly inputs: {getInput: (name: string) => string; getBooleanInput: (name: string) => boolean},
-    private readonly files: Files,
-    private readonly logger: Logger,
-  ) {}
+    inputs: ActionInputs,
+    files: Files,
+    logger: Logger,
+  ) {
+    this.inputs = inputs
+    this.files = files
+    this.logger = logger
+  }
 
   /**
    * Returns every input for this action.

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -26,12 +26,22 @@ export class Workspace {
 
   private intervalId: NodeJS.Timeout | undefined
 
+  private readonly logger: Logger
+  private readonly files: Files
+  private readonly os: OSInfo
+  private readonly cache: ActionCache
+
   constructor(
-    private readonly logger: Logger,
-    private readonly files: Files,
-    private readonly os: OSInfo,
-    private readonly cache: ActionCache,
+    logger: Logger,
+    files: Files,
+    os: OSInfo,
+    cache: ActionCache,
   ) {
+    this.logger = logger
+    this.files = files
+    this.os = os
+    this.cache = cache
+
     this.directory = path.join(this.os.homedir(), 'scala-steward')
     this.workspace = mandatory(path.join(this.directory, 'workspace'))
     this.repos_md = mandatory(path.join(this.directory, 'repos.md'))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "module": "es2022",
-    "target": "es2024",
     "moduleResolution": "bundler",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "erasableSyntaxOnly": true
   }
 }


### PR DESCRIPTION
Follows #843. This is the second of three PRs moving the action onto Node 24 built-ins. The next one drops `ts-node`, `ava`, `sinon` and `c8`.

## What

Rewrites the five constructors that used TypeScript parameter properties (`constructor(private readonly logger: Logger)`) into an explicit field declaration plus an assignment, and turns on `erasableSyntaxOnly`.

## Why

Node's built-in TypeScript support runs in **strip-only** mode. It replaces type annotations with whitespace and refuses any syntax that would require a real transform, so a parameter property fails with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`. This is the one thing standing between this repo and dropping `ts-node`.

The escape hatch used to be `--experimental-transform-types`, but that flag was **removed outright in Node 26.0.0** with no replacement, so rewriting the constructors is the option that keeps working rather than a workaround with a shelf life.

`erasableSyntaxOnly` makes `tsc` fail if un-erasable syntax is ever reintroduced, which keeps the next PR from silently regressing.

The tsconfig base also moves from `@tsconfig/node20` to `@tsconfig/node24`, matching the runtime the action already declares in `action.yml` (`using: node24`) and in `engines`. The now-redundant `target` override is dropped since the new base already sets `es2024`.

## Notes for review

- `Input` gains an exported `ActionInputs` type alias. Without it the inline `{getInput, getBooleanInput}` type would have been spelled out a third time. It is structurally identical, so callers and tests are unaffected.
- No behaviour changes. This is purely a syntax move.

## Verification

`npx tsc --noEmit` passes with `erasableSyntaxOnly` on, which is the authoritative check that nothing un-erasable remains. `npm run all` passes on Node 24.18.1 with all 37 tests green and the coverage report unchanged at 60.76%.